### PR TITLE
chore: optimize Renovate configuration for weekend maintenance

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,26 @@
 {
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base"
+  ],
+  "schedule": [
+    "after 10pm Friday",
+    "before 5am Monday"
+  ],
+  "timezone": "America/New_York",
+  "dependencyDashboard": true,
+  "prConcurrentLimit": 5,
+  "packageRules": [
+    {
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
+      "groupName": "all non-major dependencies",
+      "automerge": false
+    }
+  ],
+  "assignees": [
+    "hubertbanas"
   ]
 }


### PR DESCRIPTION
- Restricted PR creation to weekends (Friday 10pm - Monday 5am) to minimize mid-week build noise.
- Set timezone to America/New_York for schedule alignment.
- Grouped all minor and patch updates into a single 'non-major' PR.
- Added automatic assignee for better notification tracking.