### PR TITLE
feat: add press-and-hold continuous level navigation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sokoban",
-  "version": "1.5.2",
+  "version": "1.6.0",
   "private": true,
   "type": "module",
   "dependencies": {

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -9,8 +9,62 @@ import style from "./components/sokoban.module.css";
 import { cn } from "./utils/classnames";
 import { styleFrom, styleDirection } from "./utils/block-styles";
 
+function useHoldToRepeat(action: () => void, delay = 320, interval = 110) {
+  const timeoutRef = React.useRef<number | null>(null);
+  const intervalRef = React.useRef<number | null>(null);
+  const suppressNextClickRef = React.useRef(false);
+
+  const stop = React.useCallback(() => {
+    if (timeoutRef.current !== null) {
+      window.clearTimeout(timeoutRef.current);
+      timeoutRef.current = null;
+    }
+
+    if (intervalRef.current !== null) {
+      window.clearInterval(intervalRef.current);
+      intervalRef.current = null;
+    }
+  }, []);
+
+  const start = React.useCallback(
+    (event: React.PointerEvent<HTMLButtonElement>) => {
+      if (event.button !== 0) return;
+
+      suppressNextClickRef.current = true;
+      action();
+      stop();
+
+      timeoutRef.current = window.setTimeout(() => {
+        intervalRef.current = window.setInterval(action, interval);
+      }, delay);
+    },
+    [action, delay, interval, stop]
+  );
+
+  const onClick = React.useCallback(() => {
+    if (suppressNextClickRef.current) {
+      suppressNextClickRef.current = false;
+      return;
+    }
+
+    action();
+  }, [action]);
+
+  React.useEffect(() => stop, [stop]);
+
+  return {
+    onClick,
+    onPointerDown: start,
+    onPointerUp: stop,
+    onPointerLeave: stop,
+    onPointerCancel: stop,
+  };
+}
+
 function Game() {
   const { index, level, state, move, next, nextLevel, previousLevel, undo, restart } = useSokoban();
+  const previousButtonHandlers = useHoldToRepeat(previousLevel);
+  const nextButtonHandlers = useHoldToRepeat(nextLevel);
   const boardVars = {
     "--level-width": level.width,
     "--level-height": level.height,
@@ -72,14 +126,14 @@ function Game() {
           <button
             type="button"
             className={style.levelNavButton}
-            onClick={previousLevel}
+            {...previousButtonHandlers}
           >
             Previous
           </button>
           <button
             type="button"
             className={style.levelNavButton}
-            onClick={nextLevel}
+            {...nextButtonHandlers}
           >
             Next
           </button>


### PR DESCRIPTION
## Overview
This PR introduces a quality-of-life enhancement for level selection, allowing players to press and hold the "Next" or "Previous" buttons to rapidly cycle through puzzles without needing to click repeatedly.

## Key Changes
* **Continuous Navigation Hook:** Added a custom `useHoldToRepeat` hook to `Game.tsx` to handle the timing logic (320ms initial delay, 110ms repeat interval).
* **Pointer Events:** Bound the new hook using modern `onPointerDown`/`onPointerUp`/`onPointerLeave`/`onPointerCancel` events, ensuring perfect cross-platform compatibility for both mouse clicks and mobile touch interactions.
* **Click Suppression:** Integrated a click-suppression reference to prevent double-firing when the pointer events and native onClick events overlap.
* **Version Bump:** Incremented the minor version in `package.json` to `1.6.0` to reflect the new interactive functionality.