### PR TITLE
ci: fix renovate configuration syntax

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,11 +1,11 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:base"
+    "config:recommended"
   ],
   "schedule": [
-    "after 10pm Friday",
-    "before 5am Monday"
+    "after 10pm on Friday",
+    "before 5am on Monday"
   ],
   "timezone": "America/New_York",
   "dependencyDashboard": true,


### PR DESCRIPTION
## Overview
This PR resolves the configuration error that was preventing Mend Renovate from successfully parsing the repository and opening the Dependency Dashboard. 

## Key Changes
* **Updated Base Preset:** Shifted from `config:base` to the enforced `config:recommended` standard.
* **Fixed Schedule Syntax:** Corrected the text-to-schedule string (added "on") to ensure it passes Renovate's strict grammar validation (`after 10pm on Friday`, `before 5am on Monday`).

Closes #20