### PR TITLE
chore: bump version to v1.16.0-rc.1 for build pipeline verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [v1.16.0-rc.1] - 2026-04-11
+
+### Added
+* Cross-Platform Desktop Branding: Implemented high-resolution custom Kenney icon assets for Windows, macOS, and Linux desktop targets.
+
+### Fixed
+* Linux GNOME/Wayland Icon Matching: Resolved an issue where desktop environments displayed a generic fallback icon while the game was running. The application main process now explicitly maps its `WM_CLASS` to the generated Flatpak `.desktop` shortcut file.
+
+### Build System & CI/CD
+* JIT (Just-In-Time) Asset Generation: Introduced `scripts/prepare-icons.sh` triggered via a `prebuild:desktop` yarn hook. This dynamically generates the strict `hicolor` icon matrix required for Flatpak AppStream validation using ImageMagick, keeping the repository clean of duplicate binary artifacts.
+
 ## [1.15.0] - 2026-04-10
 
 ### Features & Branding

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sokoban",
-  "version": "1.15.0",
+  "version": "1.16.0-rc.1",
   "private": true,
   "type": "module",
   "main": "electron-main.cjs",


### PR DESCRIPTION
### Description
This Pull Request prepares the `v1.16.0-rc.1` Release Candidate. The primary goal of this RC is to validate the recent cross-platform desktop packaging and CI/CD workflow overhauls in a live GitHub Actions environment before cutting the final `v1.16.0` production release.

### Release Candidate Verification Goals
This RC deployment will be actively monitored to verify:
* **JIT Asset Generation:** Ensure the `ubuntu-latest` runner correctly triggers `prepare-icons.sh` and successfully utilizes its native ImageMagick to generate the Flatpak icon matrix.
* **Linux Strict Validations:** Confirm Flatpak passes AppStream validation on the live runner.