### PR TITLE
chore: bump version to 1.16.0-rc.2 and fix changelog formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Changelog
 
-## [v1.16.0-rc.1] - 2026-04-11
+## [1.16.0-rc.2] - 2026-04-11
+
+### Fixed
+* Corrected version header formatting in the changelog to align with project standards.
+
+## [1.16.0-rc.1] - 2026-04-11
 
 ### Added
 * Cross-Platform Desktop Branding: Implemented high-resolution custom Kenney icon assets for Windows, macOS, and Linux desktop targets.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sokoban",
-  "version": "1.16.0-rc.1",
+  "version": "1.16.0-rc.2",
   "private": true,
   "type": "module",
   "main": "electron-main.cjs",


### PR DESCRIPTION
### Description
This Pull Request bumps the Release Candidate version to `1.16.0-rc.2` to trigger a fresh CI/CD pipeline run and corrects a formatting inconsistency in the changelog.

### Key Changes
* **Changelog Fix:** Corrected the version header format in `CHANGELOG.md` by removing the leading `v` inside the brackets (changed `[v1.16.0-rc.1]` to `[1.16.0-rc.1]`) to match the repository's established standard.
* **Version Bump:** Updated `package.json` to `1.16.0-rc.2` for the next automated release test.