### PR TITLE
chore: bump version to 1.16.0-rc.3 for macOS pipeline verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## [1.16.0-rc.3] - 2026-04-11
+
+### Fixed
+* macOS ARM64 Build Panic: Bypassed a fatal `kingpin` panic in `electron-builder` by pre-generating the Apple `.icns` asset using native macOS `sips` and `iconutil` CLI tools prior to packaging.
+
 ## [1.16.0-rc.2] - 2026-04-11
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sokoban",
-  "version": "1.16.0-rc.2",
+  "version": "1.16.0-rc.3",
   "private": true,
   "type": "module",
   "main": "electron-main.cjs",


### PR DESCRIPTION
### Description
This Pull Request bumps the Release Candidate version to `1.16.0-rc.3` to validate the recent native macOS icon generation fixes on the GitHub Actions runner.

### Release Candidate Verification Goals
The primary goal of this RC is to confirm that the `macos-latest` (ARM64) runner successfully executes the updated `scripts/prepare-icons.sh` logic. Specifically, it will verify that:
* The script correctly detects the `Darwin` OS.
* Apple's native `sips` and `iconutil` tools successfully pre-generate `build/icon.icns`.
* The `electron-builder` step detects the pre-generated file and entirely bypasses its internal `app-builder` conversion, successfully avoiding the `kingpin` panic.