### PR TITLE
chore: release v1.16.0 production build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## [1.16.0] - 2026-04-11
+
+### Added
+* Cross-Platform Desktop Branding: Implemented high-resolution custom Kenney icon assets for all desktop targets, completely replacing the default Electron graphics for Windows, macOS, and Linux.
+
+### Fixed
+* Linux GNOME/Wayland Icon Matching: Resolved an issue where desktop environments displayed a generic fallback icon while the game was running. The application main process now explicitly maps its `WM_CLASS` to the generated Flatpak `.desktop` shortcut file.
+* macOS ARM64 Build Panic: Bypassed a fatal `kingpin` panic in `electron-builder` on Apple Silicon runners by pre-generating the Apple `.icns` asset using native macOS `sips` and `iconutil` CLI tools prior to packaging.
+
+### Build System & CI/CD
+* JIT (Just-In-Time) Asset Generation: Introduced `scripts/prepare-icons.sh` triggered via a `prebuild:desktop` yarn hook. This dynamically generates the strict `hicolor` icon matrix required for Flatpak AppStream validation using ImageMagick (or a native `sips` fallback on macOS), keeping the repository clean of duplicate binary artifacts.
+
 ## [1.16.0-rc.3] - 2026-04-11
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sokoban",
-  "version": "1.16.0-rc.3",
+  "version": "1.16.0",
   "private": true,
   "type": "module",
   "main": "electron-main.cjs",


### PR DESCRIPTION
### Title
chore: release v1.16.0 production build

### Description
This Pull Request cuts the final `v1.16.0` production release. The `1.16.0-rc.X` testing phase successfully validated major CI/CD overhauls and cross-platform desktop packaging upgrades.

### Release Highlights
* **Cross-Platform Branding:** Implemented high-resolution custom Kenney icon assets for Windows, macOS, and Linux.
* **Linux Desktop Fixes:** Resolved Wayland/GNOME taskbar icon matching by explicitly binding the `WM_CLASS` to the Flatpak `.desktop` shortcut.
* **Bulletproof CI/CD:**
  * Implemented a native macOS bypass (`sips`/`iconutil`) to completely eliminate `electron-builder` panics on ARM64 runners.
  * Added Just-In-Time (JIT) AppStream icon matrix generation for Linux strict sandbox validation.