### PR TITLE
fix: improve Flatpak metainfo checksum and signature generation process

### DIFF
--- a/.github/workflows/publish-desktop.yml
+++ b/.github/workflows/publish-desktop.yml
@@ -169,10 +169,14 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           set -euo pipefail
-          metainfo_file="build/flatpak/com.hubertbanas.sokoban.metainfo.xml"
-          sha256sum "$metainfo_file" > "${metainfo_file}.sha256"
-          gpg --batch --yes --armor --detach-sign --output "${metainfo_file}.asc" "$metainfo_file"
-          gpg --batch --yes --armor --detach-sign --output "${metainfo_file}.sha256.asc" "${metainfo_file}.sha256"
+          metainfo_dir="build/flatpak"
+          metainfo_name="com.hubertbanas.sokoban.metainfo.xml"
+          (
+            cd "$metainfo_dir"
+            sha256sum "$metainfo_name" > "${metainfo_name}.sha256"
+            gpg --batch --yes --armor --detach-sign --output "${metainfo_name}.asc" "$metainfo_name"
+            gpg --batch --yes --armor --detach-sign --output "${metainfo_name}.sha256.asc" "${metainfo_name}.sha256"
+          )
 
       - name: Generate MacOS checksums and signatures
         if: runner.os == 'macOS'


### PR DESCRIPTION
### Description
The release verification script (`verify-release.sh`) was failing during the SHA-256 validation phase for `com.hubertbanas.sokoban.metainfo.xml`. 

The root cause was that the generated `.sha256` file incorrectly embedded the local relative build path (`build/flatpak/com.hubertbanas.sokoban.metainfo.xml`) instead of the file's basename. When the release artifacts were downloaded into a single flat directory, `sha256sum -c` failed because it was looking for a `build/flatpak/` sub-directory that did not exist in the download location.

### Key Changes
* Updated the checksum and signature generation process to strip the local build directory path.
* The `.sha256` file now correctly references only the `com.hubertbanas.sokoban.metainfo.xml` basename, ensuring it validates seamlessly alongside the rest of the flat release artifacts.