### PR TITLE
fix: migrate to Web Audio API for zero-latency mobile playback

### DIFF
--- a/src/hooks/useGameSounds.ts
+++ b/src/hooks/useGameSounds.ts
@@ -17,6 +17,13 @@ type SfxSettings = {
   volume: number;
 };
 
+type WebAudioResources = {
+  context: AudioContext;
+  masterGain: GainNode;
+};
+
+type AudioContextConstructor = new (options?: AudioContextOptions) => AudioContext;
+
 const SFX_SETTINGS_STORAGE_KEY = "sokoban.sfx.settings";
 
 const DEFAULT_SFX_SETTINGS: SfxSettings = {
@@ -68,10 +75,128 @@ function readStoredSfxSettings(): SfxSettings {
   }
 }
 
+function getAudioContextConstructor(): AudioContextConstructor | null {
+  if (typeof window === "undefined") {
+    return null;
+  }
+
+  const webkitWindow = window as Window & {
+    webkitAudioContext?: AudioContextConstructor;
+  };
+
+  return (window.AudioContext as AudioContextConstructor | undefined)
+    ?? webkitWindow.webkitAudioContext
+    ?? null;
+}
+
 export function useGameSounds() {
+  const webAudioRef = useRef<WebAudioResources | null>(null);
+  const decodedBuffersRef = useRef<Partial<Record<GameSoundName, AudioBuffer>>>({});
+  const loadingBuffersRef = useRef<Partial<Record<GameSoundName, Promise<void>>>>({});
+  const unlockedWebAudioRef = useRef(false);
   const activeSoundsRef = useRef(new Set<HTMLAudioElement>());
   const [settings, setSettings] = useState<SfxSettings>(readStoredSfxSettings);
   const settingsRef = useRef(settings);
+
+  const ensureWebAudio = useCallback((): WebAudioResources | null => {
+    if (webAudioRef.current) {
+      return webAudioRef.current;
+    }
+
+    const AudioContextCtor = getAudioContextConstructor();
+    if (!AudioContextCtor) {
+      return null;
+    }
+
+    let context: AudioContext;
+    try {
+      context = new AudioContextCtor({ latencyHint: "interactive" });
+    } catch {
+      context = new AudioContextCtor();
+    }
+
+    const masterGain = context.createGain();
+    masterGain.connect(context.destination);
+
+    webAudioRef.current = {
+      context,
+      masterGain,
+    };
+
+    return webAudioRef.current;
+  }, []);
+
+  const setMasterGainFromSettings = useCallback((nextSettings: SfxSettings) => {
+    const webAudio = webAudioRef.current;
+    if (!webAudio) {
+      return;
+    }
+
+    const nextGain = nextSettings.muted ? 0 : clampVolume(nextSettings.volume);
+    webAudio.masterGain.gain.setTargetAtTime(nextGain, webAudio.context.currentTime, 0.01);
+  }, []);
+
+  const loadDecodedBuffer = useCallback(
+    (name: GameSoundName): Promise<void> => {
+      if (decodedBuffersRef.current[name]) {
+        return Promise.resolve();
+      }
+
+      const existingTask = loadingBuffersRef.current[name];
+      if (existingTask) {
+        return existingTask;
+      }
+
+      const webAudio = ensureWebAudio();
+      if (!webAudio) {
+        return Promise.resolve();
+      }
+
+      const task = fetch(SOUND_SOURCES[name], { cache: "force-cache" })
+        .then((response) => response.arrayBuffer())
+        .then((audioData) => webAudio.context.decodeAudioData(audioData.slice(0)))
+        .then((decodedBuffer) => {
+          decodedBuffersRef.current[name] = decodedBuffer;
+        })
+        .catch(() => undefined)
+        .finally(() => {
+          delete loadingBuffersRef.current[name];
+        });
+
+      loadingBuffersRef.current[name] = task;
+      return task;
+    },
+    [ensureWebAudio]
+  );
+
+  const preloadDecodedBuffers = useCallback(() => {
+    (Object.keys(SOUND_SOURCES) as GameSoundName[]).forEach((name) => {
+      void loadDecodedBuffer(name);
+    });
+  }, [loadDecodedBuffer]);
+
+  const unlockWebAudio = useCallback(() => {
+    if (unlockedWebAudioRef.current) {
+      return;
+    }
+
+    const webAudio = ensureWebAudio();
+    if (!webAudio) {
+      unlockedWebAudioRef.current = true;
+      return;
+    }
+
+    if (webAudio.context.state === "suspended") {
+      void webAudio.context.resume().then(() => {
+        unlockedWebAudioRef.current = true;
+        preloadDecodedBuffers();
+      }).catch(() => undefined);
+      return;
+    }
+
+    unlockedWebAudioRef.current = true;
+    preloadDecodedBuffers();
+  }, [ensureWebAudio, preloadDecodedBuffers]);
 
   useEffect(() => {
     settingsRef.current = settings;
@@ -80,6 +205,7 @@ export function useGameSounds() {
     }
 
     window.localStorage.setItem(SFX_SETTINGS_STORAGE_KEY, JSON.stringify(settings));
+    setMasterGainFromSettings(settings);
   }, [settings]);
 
   useEffect(() => {
@@ -100,7 +226,37 @@ export function useGameSounds() {
   }, []);
 
   useEffect(() => {
+    ensureWebAudio();
+    setMasterGainFromSettings(settingsRef.current);
+    preloadDecodedBuffers();
+  }, [ensureWebAudio, preloadDecodedBuffers, setMasterGainFromSettings]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    const unlock = () => {
+      unlockWebAudio();
+    };
+
+    window.addEventListener("pointerdown", unlock, true);
+    window.addEventListener("keydown", unlock, true);
+
     return () => {
+      window.removeEventListener("pointerdown", unlock, true);
+      window.removeEventListener("keydown", unlock, true);
+    };
+  }, [unlockWebAudio]);
+
+  useEffect(() => {
+    return () => {
+      const webAudio = webAudioRef.current;
+      if (webAudio) {
+        void webAudio.context.close().catch(() => undefined);
+        webAudioRef.current = null;
+      }
+
       activeSoundsRef.current.forEach((audio) => {
         audio.pause();
         audio.src = "";
@@ -109,13 +265,53 @@ export function useGameSounds() {
     };
   }, []);
 
+  const playViaWebAudio = useCallback(
+    (name: GameSoundName): boolean => {
+      const webAudio = ensureWebAudio();
+      if (!webAudio) {
+        return false;
+      }
+
+      const decodedBuffer = decodedBuffersRef.current[name];
+      if (!decodedBuffer) {
+        void loadDecodedBuffer(name);
+        return false;
+      }
+
+      if (webAudio.context.state === "suspended") {
+        void webAudio.context.resume().catch(() => undefined);
+      }
+
+      if (webAudio.context.state !== "running") {
+        return false;
+      }
+
+      const source = webAudio.context.createBufferSource();
+      source.buffer = decodedBuffer;
+
+      const sourceGain = webAudio.context.createGain();
+      sourceGain.gain.value = SOUND_VOLUMES[name];
+
+      source.connect(sourceGain);
+      sourceGain.connect(webAudio.masterGain);
+      source.start();
+
+      return true;
+    },
+    [ensureWebAudio, loadDecodedBuffer]
+  );
+
   const play = useCallback((name: GameSoundName) => {
-    if (typeof Audio === "undefined") {
+    const currentSettings = settingsRef.current;
+    if (currentSettings.muted || currentSettings.volume <= 0) {
       return;
     }
 
-    const currentSettings = settingsRef.current;
-    if (currentSettings.muted || currentSettings.volume <= 0) {
+    if (playViaWebAudio(name)) {
+      return;
+    }
+
+    if (typeof Audio === "undefined") {
       return;
     }
 
@@ -136,7 +332,7 @@ export function useGameSounds() {
     void audio.play().catch(() => {
       cleanup();
     });
-  }, []);
+  }, [playViaWebAudio]);
 
   const playCratePush = useCallback(() => {
     play("crate-push");

--- a/src/hooks/useGameSounds.ts
+++ b/src/hooks/useGameSounds.ts
@@ -89,6 +89,33 @@ function getAudioContextConstructor(): AudioContextConstructor | null {
     ?? null;
 }
 
+function decodeAudioDataCompat(context: AudioContext, audioData: ArrayBuffer): Promise<AudioBuffer> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+
+    const resolveOnce = (buffer: AudioBuffer) => {
+      if (settled) return;
+      settled = true;
+      resolve(buffer);
+    };
+
+    const rejectOnce = (error: unknown) => {
+      if (settled) return;
+      settled = true;
+      reject(error);
+    };
+
+    try {
+      const decodeResult = context.decodeAudioData(audioData, resolveOnce, rejectOnce);
+      if (decodeResult && typeof decodeResult.then === "function") {
+        decodeResult.then(resolveOnce).catch(rejectOnce);
+      }
+    } catch (error) {
+      rejectOnce(error);
+    }
+  });
+}
+
 export function useGameSounds() {
   const webAudioRef = useRef<WebAudioResources | null>(null);
   const decodedBuffersRef = useRef<Partial<Record<GameSoundName, AudioBuffer>>>({});
@@ -154,7 +181,7 @@ export function useGameSounds() {
 
       const task = fetch(SOUND_SOURCES[name], { cache: "force-cache" })
         .then((response) => response.arrayBuffer())
-        .then((audioData) => webAudio.context.decodeAudioData(audioData.slice(0)))
+        .then((audioData) => decodeAudioDataCompat(webAudio.context, audioData.slice(0)))
         .then((decodedBuffer) => {
           decodedBuffersRef.current[name] = decodedBuffer;
         })
@@ -280,10 +307,6 @@ export function useGameSounds() {
 
       if (webAudio.context.state === "suspended") {
         void webAudio.context.resume().catch(() => undefined);
-      }
-
-      if (webAudio.context.state !== "running") {
-        return false;
       }
 
       const source = webAudio.context.createBufferSource();


### PR DESCRIPTION
### Description
This Pull Request addresses a significant audio latency issue on Android WebView/Capacitor builds where sound effects (step, bump, push) were firing noticeably after the visual frame updates. The audio engine has been refactored to prioritize the low-latency Web Audio API, falling back to the standard HTML5 `<audio>` element only when necessary.

### Key Changes
* **Web Audio API Migration:** Transitioned the `useGameSounds` hook to utilize `AudioContext` with `latencyHint: "interactive"`. Sound effects are now pre-fetched, decoded into `AudioBuffer` objects, and dynamically routed through a master `GainNode` for instantaneous playback scheduling.
* **Mobile Context Unlocking:** Implemented a global listener to automatically resume the suspended `AudioContext` on the first `pointerdown` or `keydown` event, satisfying modern mobile browser autoplay policies.
* **First-Tap Latency Fix:** Removed synchronous state-checking during node scheduling. The engine now inherently relies on the Web Audio API's native queue to fire the first sound exactly when the context asynchronously resumes, preventing fallback to the slower HTML5 path.
* **Cross-Browser Decoding Compat:** Added a defensive `decodeAudioDataCompat` wrapper to handle legacy iOS/WebKit environments that only support callback-based `decodeAudioData` rather than the modern Promise-based specification.

### Testing Performed
- [x] Verified zero-latency audio playback during rapid directional inputs on an Android physical device.