### PR TITLE
fix: update Flatpak runtime to 24.08

### DIFF
--- a/.github/workflows/publish-desktop.yml
+++ b/.github/workflows/publish-desktop.yml
@@ -61,8 +61,26 @@ jobs:
       - name: Install Linux build dependencies
         if: runner.os == 'Linux'
         run: |
+          set -euo pipefail
           sudo apt-get update
-          sudo apt-get install -y flatpak flatpak-builder elfutils rpm libarchive-tools zstd imagemagick appstream
+          sudo apt-get install -y flatpak flatpak-builder elfutils rpm libarchive-tools zstd imagemagick appstream appstream-compose appstream-util
+
+          FLATPAK_BUILDER_VERSION="$(flatpak-builder --version | grep -oE '[0-9]+(\.[0-9]+)+' | head -n 1)"
+          if [ -z "$FLATPAK_BUILDER_VERSION" ]; then
+            echo "Unable to parse flatpak-builder version output."
+            exit 1
+          fi
+
+          if ! dpkg --compare-versions "$FLATPAK_BUILDER_VERSION" ge 1.4.0; then
+            echo "flatpak-builder >= 1.4.0 is required (found $FLATPAK_BUILDER_VERSION)."
+            exit 1
+          fi
+
+          if ! command -v appstream-compose >/dev/null 2>&1; then
+            echo "appstream-compose binary is required but was not found in PATH."
+            exit 1
+          fi
+
           flatpak --user remote-add --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo
 
       - name: Linux build tooling diagnostics
@@ -70,6 +88,8 @@ jobs:
         run: |
           flatpak --version
           flatpak-builder --version
+          appstreamcli --version || true
+          appstream-compose --help | sed -n '1,1p' || true
           magick --version || true
           convert -version || true
           flatpak remotes --user

--- a/docs/development.md
+++ b/docs/development.md
@@ -111,6 +111,7 @@ docker compose -f compose.dev.yaml up -d
 ### Production (`compose.prod.yaml`)
 
 ```bash
+docker compose -f compose.prod.yaml pull
 docker compose -f compose.prod.yaml up -d
 ```
 

--- a/package.json
+++ b/package.json
@@ -161,6 +161,8 @@
     },
     "flatpak": {
       "branch": "stable",
+      "runtimeVersion": "24.08",
+      "baseVersion": "24.08",
       "files": [
         [
           "build/flatpak/com.hubertbanas.sokoban.metainfo.xml",

--- a/scripts/build-releases.sh
+++ b/scripts/build-releases.sh
@@ -1093,8 +1093,11 @@ run_flatpak() {
   log "Step flatpak: building Linux Flatpak (${LINUX_ARCH})..."
   docker_node_bookworm_script "
     set -euo pipefail
+    export DEBIAN_FRONTEND=noninteractive
+    echo 'deb http://deb.debian.org/debian bookworm-backports main' > /etc/apt/sources.list.d/bookworm-backports.list
     apt-get update
-    apt-get install -y flatpak flatpak-builder dbus elfutils imagemagick appstream
+    apt-get install -y --no-install-recommends -t bookworm-backports flatpak flatpak-builder elfutils
+    apt-get install -y --no-install-recommends dbus imagemagick appstream appstream-compose appstream-util
     mkdir -p /var/lib/dbus
     dbus-uuidgen > /var/lib/dbus/machine-id
     flatpak remote-add --user --if-not-exists flathub https://dl.flathub.org/repo/flathub.flatpakrepo


### PR DESCRIPTION
### Description
This Pull Request addresses the End-of-Life (EOL) security warnings generated by the previous Freedesktop 20.08 Flatpak runtime. It bumps the target SDK to the modern 24.08 branch and introduces the necessary build-chain upgrades - both locally and in CI/CD - to support the stricter AppStream catalog generation requirements enforced by the new runtime. Additionally, it includes a minor update to the Docker deployment documentation.

### Key Changes
* **Flatpak Runtime Bump:** Updated `package.json` to explicitly target `runtimeVersion` and `baseVersion` 24.08, resolving EOL warnings.
* **Local Build Tooling Upgrade:** Modified `scripts/build-releases.sh` to pull modern packaging tools (`flatpak` and `flatpak-builder`) from the `bookworm-backports` repository. Included `appstream-compose` and `appstream-util` to prevent `bwrap` execution crashes during the final Flatpak packaging phase.
* **CI/CD Pipeline Hardening:** Updated `.github/workflows/publish-desktop.yml` to install the newly required AppStream dependencies. Added explicit fail-fast validation checks to ensure the GitHub Actions runner provides `flatpak-builder >= 1.4.0` and the `appstream-compose` binary before attempting a build.
* **Documentation:** Added an explicit `docker compose pull` step to `docs/development.md` to ensure production deployments fetch the latest remote image before spinning up containers.

### Testing Performed
- [x] Verified local `build-releases.sh` completes the Flatpak build successfully without `appstream-compose` errors.
- [x] Confirmed the generated Flatpak metadata passes validation against the 24.08 runtime.