### PR TITLE
fix: update player facing on blocked movement

### DIFF
--- a/src/hooks/sokoban.test.ts
+++ b/src/hooks/sokoban.test.ts
@@ -1,0 +1,61 @@
+import "@testing-library/jest-dom/vitest";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, expect, test, vi } from "vitest";
+import { useSokoban, Direction, type MoveOutcome } from "./sokoban";
+import { Block, useLevels, type Level } from "./levels";
+
+vi.mock("./levels", async () => {
+    const actual = await vi.importActual<typeof import("./levels")>("./levels");
+    return {
+        ...actual,
+        useLevels: vi.fn(),
+    };
+});
+
+const mockedUseLevels = vi.mocked(useLevels);
+
+function createLevel(shape: Block[][]): Level {
+    return {
+        name: "Blocked orientation regression",
+        width: shape[0].length,
+        height: shape.length,
+        shape,
+    };
+}
+
+beforeEach(() => {
+    mockedUseLevels.mockReset();
+    localStorage.clear();
+});
+
+test("blocked movement updates player orientation without moving or adding progress", () => {
+    const level = createLevel([
+        [Block.wall, Block.wall, Block.wall],
+        [Block.wall, Block.player, Block.wall],
+        [Block.wall, Block.empty, Block.wall],
+    ]);
+
+    mockedUseLevels.mockReturnValue({
+        index: 0,
+        level,
+        loadNext: vi.fn(),
+        loadPrevious: vi.fn(),
+    });
+
+    const { result } = renderHook(() => useSokoban());
+
+    expect(result.current.level.playerDirection).toBe(Direction.Right);
+    expect(result.current.level.playerPosition).toEqual({ row: 1, column: 1 });
+    expect(result.current.hasProgress).toBe(false);
+
+    let outcome: MoveOutcome = "step";
+    act(() => {
+        outcome = result.current.move(Direction.Top);
+    });
+
+    expect(outcome).toBe("blocked");
+    expect(result.current.level.playerDirection).toBe(Direction.Top);
+    expect(result.current.level.playerPosition).toEqual({ row: 1, column: 1 });
+    expect(result.current.level.shape[1][1]).toBe(Block.player);
+    expect(result.current.hasProgress).toBe(false);
+});

--- a/src/hooks/sokoban.ts
+++ b/src/hooks/sokoban.ts
@@ -139,6 +139,10 @@ export function useSokoban() {
         return "step";
       }
 
+      if (last.playerDirection !== direction) {
+        setBoard([...board.slice(0, -1), { ...last, playerDirection: direction }]);
+      }
+
       return "blocked";
     },
     [board, state]


### PR DESCRIPTION
### Description
This Pull Request resolves an issue where the player sprite would not update its orientation when attempting to move into a blocked tile. The movement logic has been adjusted to capture the attempted direction so the sprite visually rotates to face the obstacle, providing better visual feedback to the player.

### Key Changes
* **Sprite Orientation Update:** Modified the blocked-move execution path to persist the attempted direction within the current board snapshot.
* **Preserved Movement Semantics:** Ensured that while the sprite orientation updates, the core movement logic remains unchanged (no tile movement occurs and the move progress counter does not increment on blocked input).
* **Test Coverage:** Added a hook-level regression test to explicitly verify that a blocked input correctly rotates the sprite orientation without altering the player's grid position.