### PR TITLE
fix: pause gameplay input while modals are open

### DIFF
--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -16,7 +16,16 @@ vi.mock("./hooks/keyboard", () => ({
 }));
 
 vi.mock("./components/help", () => ({
-  Help: () => <div data-testid="help" />,
+  Help: ({ onOpenChange }: { onOpenChange?: (open: boolean) => void }) => (
+    <div data-testid="help">
+      <button type="button" data-testid="help-open" onClick={() => onOpenChange?.(true)}>
+        Open Help
+      </button>
+      <button type="button" data-testid="help-close" onClick={() => onOpenChange?.(false)}>
+        Close Help
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock("./components/theme-switcher", () => ({
@@ -28,7 +37,16 @@ vi.mock("./components/mobile-controls", () => ({
 }));
 
 vi.mock("./components/sfx-settings", () => ({
-  SfxSettings: () => <div data-testid="sfx-settings" />,
+  SfxSettings: ({ onOpenChange }: { onOpenChange?: (open: boolean) => void }) => (
+    <div data-testid="sfx-settings">
+      <button type="button" data-testid="sfx-open" onClick={() => onOpenChange?.(true)}>
+        Open SFX
+      </button>
+      <button type="button" data-testid="sfx-close" onClick={() => onOpenChange?.(false)}>
+        Close SFX
+      </button>
+    </div>
+  ),
 }));
 
 vi.mock("./hooks/useGameSounds", () => ({
@@ -579,6 +597,64 @@ test("arrow keys trigger player movement", () => {
   act(() => {
     onKeyboardEvent(createKeyboardEvent("ArrowRight").event);
   });
+  expect(move).toHaveBeenCalledWith(Direction.Right);
+});
+
+test("arrow keys are ignored while help modal is open", () => {
+  const move = vi.fn();
+  mockSokoban({ state: State.playing, move });
+
+  render(<Game />);
+
+  fireEvent.click(screen.getByTestId("help-open"));
+
+  const onKeyboardEvent = getLatestKeyboardHandler();
+  const { event, preventDefaultSpy } = createKeyboardEvent("ArrowUp");
+
+  act(() => {
+    onKeyboardEvent(event);
+  });
+
+  expect(move).not.toHaveBeenCalled();
+  expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
+
+  fireEvent.click(screen.getByTestId("help-close"));
+
+  const onKeyboardEventAfterClose = getLatestKeyboardHandler();
+
+  act(() => {
+    onKeyboardEventAfterClose(createKeyboardEvent("ArrowUp").event);
+  });
+
+  expect(move).toHaveBeenCalledWith(Direction.Top);
+});
+
+test("arrow keys are ignored while sfx modal is open", () => {
+  const move = vi.fn();
+  mockSokoban({ state: State.playing, move });
+
+  render(<Game />);
+
+  fireEvent.click(screen.getByTestId("sfx-open"));
+
+  const onKeyboardEvent = getLatestKeyboardHandler();
+  const { event, preventDefaultSpy } = createKeyboardEvent("ArrowRight");
+
+  act(() => {
+    onKeyboardEvent(event);
+  });
+
+  expect(move).not.toHaveBeenCalled();
+  expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
+
+  fireEvent.click(screen.getByTestId("sfx-close"));
+
+  const onKeyboardEventAfterClose = getLatestKeyboardHandler();
+
+  act(() => {
+    onKeyboardEventAfterClose(createKeyboardEvent("ArrowRight").event);
+  });
+
   expect(move).toHaveBeenCalledWith(Direction.Right);
 });
 

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -112,6 +112,9 @@ function Game() {
   const cancelButtonRef = React.useRef<HTMLButtonElement | null>(null);
   const confirmButtonRef = React.useRef<HTMLButtonElement | null>(null);
   const [tileSize, setTileSize] = React.useState(24);
+  const [isHelpModalOpen, setIsHelpModalOpen] = React.useState(false);
+  const [isSfxModalOpen, setIsSfxModalOpen] = React.useState(false);
+  const isAuxModalOpen = isHelpModalOpen || isSfxModalOpen;
 
   type PendingAction = "restart" | "previous" | "next" | null;
   const [pendingAction, setPendingAction] = React.useState<PendingAction>(null);
@@ -194,7 +197,7 @@ function Game() {
 
   const onMove = React.useCallback(
     (direction: Direction) => {
-      if (state !== State.playing) {
+      if (state !== State.playing || isAuxModalOpen || isConfirmationDialogOpen) {
         return;
       }
 
@@ -214,7 +217,16 @@ function Game() {
           break;
       }
     },
-    [move, playCrateDocked, playCratePush, playPlayerBump, playPlayerStep, state]
+    [
+      isAuxModalOpen,
+      isConfirmationDialogOpen,
+      move,
+      playCrateDocked,
+      playCratePush,
+      playPlayerBump,
+      playPlayerStep,
+      state,
+    ]
   );
 
   const previousStateRef = React.useRef(state);
@@ -345,6 +357,11 @@ function Game() {
         return;
       }
 
+      if (isAuxModalOpen) {
+        event.preventDefault();
+        return;
+      }
+
       switch (event.code) {
         case "ArrowUp":
           onMove(Direction.Top);
@@ -415,8 +432,9 @@ function Game() {
             volume={volume}
             onMutedChange={setMuted}
             onVolumeChange={setVolume}
+            onOpenChange={setIsSfxModalOpen}
           />
-          <Help />
+          <Help onOpenChange={setIsHelpModalOpen} />
           <ThemeSwitcher />
         </div>
       </header>

--- a/src/components/help.tsx
+++ b/src/components/help.tsx
@@ -2,11 +2,19 @@ import React, { useEffect, useState } from "react";
 import style from "./sokoban.module.css";
 import { Modal } from "./modal";
 
-function HelpImpl() {
+type HelpProps = {
+  onOpenChange?: (open: boolean) => void;
+};
+
+function HelpImpl({ onOpenChange }: HelpProps) {
   const [open, setOpen] = useState(false);
   const suppressNextClickRef = React.useRef(false);
 
   const openAbout = React.useCallback(() => setOpen(true), []);
+
+  useEffect(() => {
+    onOpenChange?.(open);
+  }, [open, onOpenChange]);
 
   const handleClick = React.useCallback(() => {
     if (suppressNextClickRef.current) {

--- a/src/components/sfx-settings.tsx
+++ b/src/components/sfx-settings.tsx
@@ -7,14 +7,19 @@ type SfxSettingsProps = {
     volume: number;
     onMutedChange: (muted: boolean) => void;
     onVolumeChange: (volume: number) => void;
+    onOpenChange?: (open: boolean) => void;
 };
 
-function SfxSettingsImpl({ muted, volume, onMutedChange, onVolumeChange }: SfxSettingsProps) {
+function SfxSettingsImpl({ muted, volume, onMutedChange, onVolumeChange, onOpenChange }: SfxSettingsProps) {
     const [open, setOpen] = React.useState(false);
     const sliderId = React.useId();
     const toggleId = React.useId();
 
     const volumePercent = Math.round(volume * 100);
+
+    React.useEffect(() => {
+        onOpenChange?.(open);
+    }, [onOpenChange, open]);
 
     React.useEffect(() => {
         if (!open) return;


### PR DESCRIPTION
### Description
This Pull Request resolves an issue where keyboard-driven gameplay continued in the background while UI overlays were active. By exposing modal visibility signals to the parent component, gameplay input is now correctly gated and paused while the Help or SFX settings modals are open.

### Key Changes
* **Input Gating:** Blocked keyboard movement interactions when the Help or SFX overlays are active.
* **Component Communication:** Added open-state callbacks to the `Help` and `SfxSettings` components. This allows the main `Game` component to evaluate visibility and block inputs, while keeping the actual modal state localized to the respective child components.
* **Test Coverage:** Added regression tests to explicitly verify that arrow key events are ignored while modals are open and properly restored once the modals are closed.