### PR TITLE
fix: update Flatpak runtime and base version to 25.08

### DIFF
--- a/package.json
+++ b/package.json
@@ -162,8 +162,8 @@
     },
     "flatpak": {
       "branch": "stable",
-      "runtimeVersion": "24.08",
-      "baseVersion": "24.08",
+      "runtimeVersion": "25.08",
+      "baseVersion": "25.08",
       "files": [
         [
           "build/flatpak/com.hubertbanas.sokoban.metainfo.xml",


### PR DESCRIPTION
### Description
This Pull Request updates the Flatpak build configuration to use the latest `25.08` stable runtime and base version. This ensures the Linux desktop packages continue to build against an actively supported SDK, preventing end-of-life deprecation warnings and maintaining compatibility with modern distribution environments.

### Key Changes
* **Runtime Upgrade:** Updated the `runtimeVersion` and `baseVersion` properties within the `flatpak` build configuration in `package.json` to `25.08`. Because `package.json` acts as the single source of truth for the desktop packager, no additional CI/CD or Docker environment changes were required.