### PR TITLE
refactor: implement dynamic level loading and deterministic identifiers

### DIFF
--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -106,6 +106,9 @@ function createKeyboardEvent(code: string) {
 
 function buildLevel() {
   return {
+    packId: "test-pack",
+    levelId: "test-pack:0",
+    puzzleId: "test-puzzle-id",
     name: "Regression Test",
     width: 3,
     height: 3,

--- a/src/datas/pack-order.ts
+++ b/src/datas/pack-order.ts
@@ -1,0 +1,7 @@
+export const configuredLevelPackOrder = [
+    "Original",
+    "Atlas01",
+    "Atlas02",
+    "Atlas03",
+    "Atlas04",
+];

--- a/src/hooks/levels.ts
+++ b/src/hooks/levels.ts
@@ -1,12 +1,14 @@
 import { useState, useMemo, useCallback } from "react";
+import { configuredLevelPackOrder } from "../datas/pack-order";
 
 export type Level = {
   name: string;
   shape: Block[][];
   width: number;
   height: number;
-  packId?: string;
-  levelId?: string;
+  packId: string;
+  levelId: string;
+  puzzleId: string;
 };
 
 export interface SokobanLevels {
@@ -37,6 +39,10 @@ const levelPackPathComparer = new Intl.Collator(undefined, {
   sensitivity: "base",
 });
 
+const prioritizedPackOrder = new Map<string, number>(
+  configuredLevelPackOrder.map((packId, index) => [packId.toLowerCase(), index])
+);
+
 type LoadedLevelPack = {
   packId: string;
   levels: SokobanLevels;
@@ -51,9 +57,34 @@ function levelIdFromParts(packId: string, levelIndex: number): string {
   return `${packId}:${levelIndex}`;
 }
 
+function compareLevelPackPaths(leftPath: string, rightPath: string): number {
+  const leftPackId = levelPackIdFromPath(leftPath);
+  const rightPackId = levelPackIdFromPath(rightPath);
+  const leftPriority = prioritizedPackOrder.get(leftPackId.toLowerCase());
+  const rightPriority = prioritizedPackOrder.get(rightPackId.toLowerCase());
+
+  if (leftPriority !== undefined || rightPriority !== undefined) {
+    if (leftPriority === undefined) return 1;
+    if (rightPriority === undefined) return -1;
+    if (leftPriority !== rightPriority) return leftPriority - rightPriority;
+  }
+
+  return levelPackPathComparer.compare(leftPath, rightPath);
+}
+
+function generatePuzzleFingerprint(layout: string[]): string {
+  const joined = layout.join("|");
+  let hash = 2166136261;
+  for (let i = 0; i < joined.length; i++) {
+    hash ^= joined.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16).padStart(8, "0");
+}
+
 function loadLevelPacks(): LoadedLevelPack[] {
   return Object.entries(levelPackModules)
-    .sort(([leftPath], [rightPath]) => levelPackPathComparer.compare(leftPath, rightPath))
+    .sort(([leftPath], [rightPath]) => compareLevelPackPaths(leftPath, rightPath))
     .map(([path, levels]) => ({
       packId: levelPackIdFromPath(path),
       levels,
@@ -149,6 +180,7 @@ function loadLevels() {
       return {
         packId,
         levelId: levelIdFromParts(packId, levelIndex),
+        puzzleId: generatePuzzleFingerprint(level.L),
         name: level.Id,
         shape: markExteriorVoid(filled),
         width,

--- a/src/hooks/levels.ts
+++ b/src/hooks/levels.ts
@@ -1,9 +1,4 @@
 import { useState, useMemo, useCallback } from "react";
-import Original from "../datas/Original.json";
-import Atlas01 from "../datas/Atlas01.json";
-import Atlas02 from "../datas/Atlas02.json";
-import Atlas03 from "../datas/Atlas03.json";
-import Atlas04 from "../datas/Atlas04.json";
 
 export type Level = {
   name: string;
@@ -28,6 +23,22 @@ export interface SokobanLevel {
   Width: string;
   Height: string;
   L: string[];
+}
+
+const levelPackModules = import.meta.glob("../datas/*.json", {
+  eager: true,
+  import: "default",
+}) as Record<string, SokobanLevels>;
+
+const levelPackPathComparer = new Intl.Collator(undefined, {
+  numeric: true,
+  sensitivity: "base",
+});
+
+function loadLevelPacks(): SokobanLevels[] {
+  return Object.entries(levelPackModules)
+    .sort(([leftPath], [rightPath]) => levelPackPathComparer.compare(leftPath, rightPath))
+    .map(([, levels]) => levels);
 }
 
 export enum Block {
@@ -102,14 +113,8 @@ function normalizeIndex(index: number, length: number) {
 }
 
 function loadLevels() {
-  const AllLevels = [
-    Original,
-    Atlas01,
-    Atlas02,
-    Atlas03,
-    Atlas04,
-  ] as SokobanLevels[];
-  return AllLevels.flatMap((levels) =>
+  const allLevels = loadLevelPacks();
+  return allLevels.flatMap((levels) =>
     levels.LevelCollection.Level.map((level) => {
       const width = Number(level.Width);
       const height = Number(level.Height);

--- a/src/hooks/levels.ts
+++ b/src/hooks/levels.ts
@@ -34,7 +34,7 @@ const levelPackModules = import.meta.glob("../datas/*.json", {
   import: "default",
 }) as Record<string, SokobanLevels>;
 
-const levelPackPathComparer = new Intl.Collator(undefined, {
+const levelPackPathComparer = new Intl.Collator("en", {
   numeric: true,
   sensitivity: "base",
 });

--- a/src/hooks/levels.ts
+++ b/src/hooks/levels.ts
@@ -5,6 +5,8 @@ export type Level = {
   shape: Block[][];
   width: number;
   height: number;
+  packId?: string;
+  levelId?: string;
 };
 
 export interface SokobanLevels {
@@ -35,10 +37,27 @@ const levelPackPathComparer = new Intl.Collator(undefined, {
   sensitivity: "base",
 });
 
-function loadLevelPacks(): SokobanLevels[] {
+type LoadedLevelPack = {
+  packId: string;
+  levels: SokobanLevels;
+};
+
+function levelPackIdFromPath(path: string): string {
+  const fileName = path.split("/").pop() ?? path;
+  return fileName.replace(/\.json$/i, "");
+}
+
+function levelIdFromParts(packId: string, levelIndex: number): string {
+  return `${packId}:${levelIndex}`;
+}
+
+function loadLevelPacks(): LoadedLevelPack[] {
   return Object.entries(levelPackModules)
     .sort(([leftPath], [rightPath]) => levelPackPathComparer.compare(leftPath, rightPath))
-    .map(([, levels]) => levels);
+    .map(([path, levels]) => ({
+      packId: levelPackIdFromPath(path),
+      levels,
+    }));
 }
 
 export enum Block {
@@ -113,9 +132,9 @@ function normalizeIndex(index: number, length: number) {
 }
 
 function loadLevels() {
-  const allLevels = loadLevelPacks();
-  return allLevels.flatMap((levels) =>
-    levels.LevelCollection.Level.map((level) => {
+  const allLevelPacks = loadLevelPacks();
+  return allLevelPacks.flatMap(({ packId, levels }) =>
+    levels.LevelCollection.Level.map((level, levelIndex) => {
       const width = Number(level.Width);
       const height = Number(level.Height);
 
@@ -128,6 +147,8 @@ function loadLevels() {
       });
 
       return {
+        packId,
+        levelId: levelIdFromParts(packId, levelIndex),
         name: level.Id,
         shape: markExteriorVoid(filled),
         width,

--- a/src/hooks/sokoban.test.ts
+++ b/src/hooks/sokoban.test.ts
@@ -16,6 +16,9 @@ const mockedUseLevels = vi.mocked(useLevels);
 
 function createLevel(shape: Block[][]): Level {
     return {
+        packId: "test-pack",
+        levelId: "test-pack:0",
+        puzzleId: "test-puzzle-id",
         name: "Blocked orientation regression",
         width: shape[0].length,
         height: shape.length,


### PR DESCRIPTION
### Description
This Pull Request introduces a foundational architectural refactor to how level packs are loaded and identified. By migrating to dynamic imports and generating immutable identifiers (pack, level, and puzzle fingerprints), this lays the necessary groundwork for the upcoming Level Pack Selection UI and cross-pack statistics tracking. No outward gameplay behavior or progression state has been altered.

### Key Changes
* **Dynamic Level Loading:** Replaced hardcoded JSON imports with Vite's `import.meta.glob` to automatically discover and load all level packs from the data directory at build time.
* **Deterministic Identifiers:** Expanded the internal `Level` data structure to require strict, deterministic IDs:
  * `packId`: Sourced directly from the filename to ensure stable pack identity.
  * `levelId`: A composite key (`packId:index`) to manage internal array math and linear progression.
  * `puzzleId`: An FNV-1a 32-bit hash generated from the raw board layout, acting as a unique fingerprint to allow future statistics to sync across duplicated puzzles in different packs.
* **Sorting and Determinism:** Hardcoded the `Intl.Collator` locale to `"en"` to guarantee identical pack sorting across all devices and prevent global index drift. 
* **Configured Pack Priority:** Introduced a `configuredLevelPackOrder` map to ensure the core progression sequence (e.g., the Original tutorial pack) remains at the front of the queue before falling back to alphabetical sorting for custom packs.
* **Type Safety:** Enforced strict requirements for the new ID fields and updated test fixtures to satisfy the new compile-time guarantees.