### PR TITLE
feat: introduce interactive tutorial level pack

### DIFF
--- a/src/datas/Tutorial.json
+++ b/src/datas/Tutorial.json
@@ -1,0 +1,45 @@
+{
+  "Title": "Tutorial",
+  "Description": "This is the tutorial pack. It introduces the core mechanics of Sokoban, from basic pushing to avoiding common traps like corners and blocked boxes.",
+  "LevelCollection": {
+    "Level": [
+      {
+        "Id": "1",
+        "Width": "10",
+        "Height": "5",
+        "L": [
+          "#####",
+          "#   ######",
+          "#@   $  .#",
+          "#   ######",
+          "#####"
+        ]
+      },
+      {
+        "Id": "2",
+        "Width": "6",
+        "Height": "6",
+        "L": [
+          "######",
+          "#    #",
+          "# .  #",
+          "#  $ #",
+          "## @ #",
+          "######"
+        ]
+      },
+      {
+        "Id": "3",
+        "Width": "8",
+        "Height": "5",
+        "L": [
+          "########",
+          "# .  $ #",
+          "# .  $@#",
+          "#      #",
+          "########"
+        ]
+      }
+    ]
+  }
+}

--- a/src/datas/pack-order.ts
+++ b/src/datas/pack-order.ts
@@ -1,4 +1,5 @@
 export const configuredLevelPackOrder = [
+    "Tutorial",
     "Original",
     "Atlas01",
     "Atlas02",


### PR DESCRIPTION
### Description
This Pull Request introduces a dedicated tutorial sequence designed to onboard new players. The pack features small, focused maps that explicitly teach core Sokoban mechanics—from basic movement to avoiding corner traps and understanding block pushing constraints. The tutorial has been prioritized to load as the very first pack in the game's sequence.

### Key Changes
* **Tutorial Pack (`Tutorial.json`):** Added a new 3-level pack.
  * Level 1: Introduces basic straight-line pushing and objective recognition.
  * Level 2: Teaches maneuvering around a box and avoiding corner traps.
  * Level 3: Demonstrates that players cannot push multiple touching boxes simultaneously.
* **Pack Ordering:** Updated `configuredLevelPackOrder` in `pack-order.ts` to place "Tutorial" as the default starting pack, shifting "Original" to the second position.