### PR TITLE
feat: implement level pack selector and pack-aware progression

### DIFF
--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -122,17 +122,42 @@ function buildLevel() {
   };
 }
 
+function buildLevelPacks() {
+  const firstLevel = {
+    ...buildLevel(),
+    levelId: "test-pack:0",
+    name: "Regression Test",
+  };
+  const secondLevel = {
+    ...buildLevel(),
+    levelId: "test-pack:1",
+    name: "Target Level",
+  };
+
+  return [
+    {
+      packId: "test-pack",
+      title: "Test Pack",
+      description: "Pack description",
+      email: "",
+      levels: [firstLevel, secondLevel],
+    },
+  ];
+}
+
 function mockSokoban(overrides: Partial<ReturnType<typeof useSokoban>> = {}) {
   const defaults = {
     index: 0,
     totalLevels: 500,
     level: buildLevel(),
+    levelPacks: buildLevelPacks(),
     state: State.playing,
     hasProgress: false,
     move: vi.fn(),
     next: vi.fn(),
     nextLevel: vi.fn(),
     previousLevel: vi.fn(),
+    loadLevel: vi.fn(),
     undo: vi.fn(),
     restart: vi.fn(),
   };
@@ -552,6 +577,62 @@ test("renders correct level number", () => {
 
   expect(screen.getByText("Level 5 / 500")).toBeInTheDocument();
   expect(screen.queryByText("The Box Puzzle")).not.toBeInTheDocument();
+});
+
+test("opens level selector modal from level number button", () => {
+  mockSokoban();
+
+  render(<Game />);
+
+  fireEvent.click(screen.getByRole("button", { name: /open level selector/i }));
+
+  expect(screen.getByRole("dialog", { name: /level pack selector/i })).toBeInTheDocument();
+  expect(screen.getByRole("heading", { name: "Test Pack" })).toBeInTheDocument();
+});
+
+test("selecting a level loads immediately when no progress exists", () => {
+  const loadLevel = vi.fn();
+  const levelPacks = buildLevelPacks();
+
+  mockSokoban({
+    hasProgress: false,
+    state: State.playing,
+    loadLevel,
+    level: levelPacks[0].levels[0],
+    levelPacks,
+  });
+
+  render(<Game />);
+
+  fireEvent.click(screen.getByRole("button", { name: /open level selector/i }));
+  fireEvent.click(screen.getByRole("button", { name: /open test pack level 2: target level/i }));
+
+  expect(loadLevel).toHaveBeenCalledWith("test-pack:1");
+  expect(screen.queryByRole("dialog", { name: /level pack selector/i })).not.toBeInTheDocument();
+});
+
+test("selecting a level opens confirmation when progress exists", () => {
+  const loadLevel = vi.fn();
+  const levelPacks = buildLevelPacks();
+
+  mockSokoban({
+    hasProgress: true,
+    state: State.playing,
+    loadLevel,
+    level: levelPacks[0].levels[0],
+    levelPacks,
+  });
+
+  render(<Game />);
+
+  fireEvent.click(screen.getByRole("button", { name: /open level selector/i }));
+  fireEvent.click(screen.getByRole("button", { name: /open test pack level 2: target level/i }));
+
+  expect(screen.getByRole("dialog", { name: /switch to selected level confirmation/i })).toBeInTheDocument();
+  expect(loadLevel).not.toHaveBeenCalled();
+
+  fireEvent.click(screen.getByRole("button", { name: "Go to Selected Level" }));
+  expect(loadLevel).toHaveBeenCalledWith("test-pack:1");
 });
 
 test("renders auxiliary components", () => {

--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -524,6 +524,21 @@ test("displays completion popup when level is completed", () => {
   expect(screen.getByTestId("mobile-controls")).toBeInTheDocument();
 });
 
+test("displays pack-complete message on the last level of the current pack", () => {
+  const levelPacks = buildLevelPacks();
+  mockSokoban({
+    state: State.completed,
+    level: levelPacks[0].levels[1],
+    levelPacks,
+  });
+
+  render(<Game />);
+
+  expect(screen.getByRole("heading", { name: /level pack complete!/i })).toBeInTheDocument();
+  expect(screen.getByText(/you completed the last level in this pack\./i)).toBeInTheDocument();
+  expect(screen.getByText(/switch to a different level pack/i)).toBeInTheDocument();
+});
+
 test("clicking continue on completion popup advances to the next level", () => {
   const next = vi.fn();
   mockSokoban({ state: State.completed, next });

--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -588,9 +588,11 @@ test("opens level selector modal from level number button", () => {
 
   expect(screen.getByRole("dialog", { name: /level pack selector/i })).toBeInTheDocument();
   expect(screen.getByRole("heading", { name: "Test Pack" })).toBeInTheDocument();
+  expect(screen.getByText("2 levels available")).toBeInTheDocument();
+  expect(screen.queryByRole("button", { name: /open test pack level/i })).not.toBeInTheDocument();
 });
 
-test("selecting a level loads immediately when no progress exists", () => {
+test("selecting a pack loads immediately when no progress exists", () => {
   const loadLevel = vi.fn();
   const levelPacks = buildLevelPacks();
 
@@ -598,20 +600,20 @@ test("selecting a level loads immediately when no progress exists", () => {
     hasProgress: false,
     state: State.playing,
     loadLevel,
-    level: levelPacks[0].levels[0],
+    level: levelPacks[0].levels[1],
     levelPacks,
   });
 
   render(<Game />);
 
   fireEvent.click(screen.getByRole("button", { name: /open level selector/i }));
-  fireEvent.click(screen.getByRole("button", { name: /open test pack level 2: target level/i }));
+  fireEvent.click(screen.getByRole("button", { name: "Play Pack" }));
 
-  expect(loadLevel).toHaveBeenCalledWith("test-pack:1");
+  expect(loadLevel).toHaveBeenCalledWith("test-pack:0");
   expect(screen.queryByRole("dialog", { name: /level pack selector/i })).not.toBeInTheDocument();
 });
 
-test("selecting a level opens confirmation when progress exists", () => {
+test("selecting a pack opens confirmation when progress exists", () => {
   const loadLevel = vi.fn();
   const levelPacks = buildLevelPacks();
 
@@ -619,20 +621,20 @@ test("selecting a level opens confirmation when progress exists", () => {
     hasProgress: true,
     state: State.playing,
     loadLevel,
-    level: levelPacks[0].levels[0],
+    level: levelPacks[0].levels[1],
     levelPacks,
   });
 
   render(<Game />);
 
   fireEvent.click(screen.getByRole("button", { name: /open level selector/i }));
-  fireEvent.click(screen.getByRole("button", { name: /open test pack level 2: target level/i }));
+  fireEvent.click(screen.getByRole("button", { name: "Play Pack" }));
 
   expect(screen.getByRole("dialog", { name: /switch to selected level confirmation/i })).toBeInTheDocument();
   expect(loadLevel).not.toHaveBeenCalled();
 
   fireEvent.click(screen.getByRole("button", { name: "Go to Selected Level" }));
-  expect(loadLevel).toHaveBeenCalledWith("test-pack:1");
+  expect(loadLevel).toHaveBeenCalledWith("test-pack:0");
 });
 
 test("renders auxiliary components", () => {

--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -2,7 +2,7 @@ import "@testing-library/jest-dom/vitest";
 import React from "react";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
-import { fireEvent, render, screen, cleanup, act } from "@testing-library/react";
+import { fireEvent, render, screen, cleanup, act, within } from "@testing-library/react";
 import { vi, expect, test, beforeAll, beforeEach, afterEach } from "vitest";
 import Game from "./Game";
 import { Block } from "./hooks/levels";
@@ -575,7 +575,9 @@ test("renders pack-aware level number", () => {
 
   render(<Game />);
 
-  expect(screen.getByText("Test Pack: Level 1 / 2")).toBeInTheDocument();
+  const levelSelectorButton = screen.getByRole("button", { name: /open level selector/i });
+  expect(within(levelSelectorButton).getByText("Test Pack")).toBeInTheDocument();
+  expect(within(levelSelectorButton).getByText("1 / 2")).toBeInTheDocument();
   expect(screen.queryByText("The Box Puzzle")).not.toBeInTheDocument();
 });
 
@@ -589,7 +591,9 @@ test("renders currently selected pack and local level index", () => {
 
   render(<Game />);
 
-  expect(screen.getByText("Test Pack: Level 2 / 2")).toBeInTheDocument();
+  const levelSelectorButton = screen.getByRole("button", { name: /open level selector/i });
+  expect(within(levelSelectorButton).getByText("Test Pack")).toBeInTheDocument();
+  expect(within(levelSelectorButton).getByText("2 / 2")).toBeInTheDocument();
 });
 
 test("opens level selector modal from level number button", () => {

--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -564,7 +564,7 @@ test("completion popup appears dynamically when state changes to completed", () 
   expect(screen.getByRole("dialog", { name: /level completed/i })).toBeInTheDocument();
 });
 
-test("renders correct level number", () => {
+test("renders pack-aware level number", () => {
   mockSokoban({
     index: 4,
     level: {
@@ -575,8 +575,21 @@ test("renders correct level number", () => {
 
   render(<Game />);
 
-  expect(screen.getByText("Level 5 / 500")).toBeInTheDocument();
+  expect(screen.getByText("Test Pack: Level 1 / 2")).toBeInTheDocument();
   expect(screen.queryByText("The Box Puzzle")).not.toBeInTheDocument();
+});
+
+test("renders currently selected pack and local level index", () => {
+  const levelPacks = buildLevelPacks();
+
+  mockSokoban({
+    level: levelPacks[0].levels[1],
+    levelPacks,
+  });
+
+  render(<Game />);
+
+  expect(screen.getByText("Test Pack: Level 2 / 2")).toBeInTheDocument();
 });
 
 test("opens level selector modal from level number button", () => {

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -427,6 +427,13 @@ function Game() {
 
     return currentPack.levels.findIndex((packLevel) => packLevel.levelId === level.levelId);
   }, [currentPack, level.levelId]);
+  const isLastLevelInCurrentPack = React.useMemo(() => {
+    if (!currentPack || currentPack.levels.length === 0 || currentPackLevelIndex < 0) {
+      return false;
+    }
+
+    return currentPackLevelIndex === currentPack.levels.length - 1;
+  }, [currentPack, currentPackLevelIndex]);
   const levelPickerPackName = currentPack?.title ?? "Levels";
   const levelPickerNumbers = React.useMemo(() => {
     if (!currentPack || currentPack.levels.length === 0) {
@@ -681,8 +688,20 @@ function Game() {
       {state === State.completed && (
         <div className={style.completionOverlay} role="dialog" aria-modal="true" aria-label="Level completed">
           <div className={style.completionCard}>
-            <h2 className={style.completionTitle}>Congratulations!</h2>
-            <p className={style.completionText}>You completed this level.</p>
+            <h2 className={style.completionTitle}>
+              {isLastLevelInCurrentPack ? "Level Pack Complete!" : "Congratulations!"}
+            </h2>
+            <p className={style.completionText}>
+              {isLastLevelInCurrentPack
+                ? "You completed the last level in this pack."
+                : "You completed this level."}
+            </p>
+            {isLastLevelInCurrentPack && (
+              <p className={style.completionText}>
+                Switch to a different level pack from the level selector, or press Continue to
+                return to Level 1 in this pack.
+              </p>
+            )}
             <button type="button" className={style.completionButton} onClick={next}>
               Continue
             </button>

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -622,7 +622,6 @@ function Game() {
         open={isLevelSelectorOpen}
         onOpenChange={setIsLevelSelectorOpen}
         levelPacks={levelPacks}
-        currentLevelId={level.levelId}
         onSelectLevel={onRequestLoadLevel}
       />
 

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -427,13 +427,14 @@ function Game() {
 
     return currentPack.levels.findIndex((packLevel) => packLevel.levelId === level.levelId);
   }, [currentPack, level.levelId]);
-  const levelPickerLabel = React.useMemo(() => {
+  const levelPickerPackName = currentPack?.title ?? "Levels";
+  const levelPickerNumbers = React.useMemo(() => {
     if (!currentPack || currentPack.levels.length === 0) {
-      return `Level ${index + 1} / ${levelCount}`;
+      return `${index + 1} / ${levelCount}`;
     }
 
     const currentPackLevelNumber = currentPackLevelIndex >= 0 ? currentPackLevelIndex + 1 : 1;
-    return `${currentPack.title}: Level ${currentPackLevelNumber} / ${currentPack.levels.length}`;
+    return `${currentPackLevelNumber} / ${currentPack.levels.length}`;
   }, [currentPack, currentPackLevelIndex, index, levelCount]);
 
   useKeyBoard(
@@ -566,12 +567,13 @@ function Game() {
 
             <button
               type="button"
-              className={`${style.levelNumber} ${style.levelPickerLevelButton}`}
+              className={style.levelPickerLevelButton}
               aria-label="Open level selector"
               title="Open level selector"
               onClick={onOpenLevelSelector}
             >
-              {levelPickerLabel}
+              <span className={style.levelPickerPackName}>{levelPickerPackName}</span>
+              <span className={style.levelPickerLevelNumbers}>{levelPickerNumbers}</span>
             </button>
 
             <button

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -416,6 +416,25 @@ function Game() {
     "--tile-radius": `${tileRadius}px`,
   } as React.CSSProperties;
   const levelCount = totalLevels ?? index + 1;
+  const currentPack = React.useMemo(
+    () => levelPacks.find((pack) => pack.packId === level.packId),
+    [level.packId, levelPacks]
+  );
+  const currentPackLevelIndex = React.useMemo(() => {
+    if (!currentPack) {
+      return -1;
+    }
+
+    return currentPack.levels.findIndex((packLevel) => packLevel.levelId === level.levelId);
+  }, [currentPack, level.levelId]);
+  const levelPickerLabel = React.useMemo(() => {
+    if (!currentPack || currentPack.levels.length === 0) {
+      return `Level ${index + 1} / ${levelCount}`;
+    }
+
+    const currentPackLevelNumber = currentPackLevelIndex >= 0 ? currentPackLevelIndex + 1 : 1;
+    return `${currentPack.title}: Level ${currentPackLevelNumber} / ${currentPack.levels.length}`;
+  }, [currentPack, currentPackLevelIndex, index, levelCount]);
 
   useKeyBoard(
     (event) => {
@@ -552,7 +571,7 @@ function Game() {
               title="Open level selector"
               onClick={onOpenLevelSelector}
             >
-              Level {index + 1} / {levelCount}
+              {levelPickerLabel}
             </button>
 
             <button

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -12,6 +12,7 @@ import style from "./components/sokoban.module.css";
 import { cn } from "./utils/classnames";
 import { styleFrom, styleDirection } from "./utils/block-styles";
 import { Modal } from "./components/modal";
+import { LevelSelectorModal } from "./components/level-selector-modal";
 
 function useHoldToRepeat(
   action: () => void,
@@ -96,7 +97,21 @@ function useHoldToRepeat(
 }
 
 function Game() {
-  const { index, level, state, move, next, nextLevel, previousLevel, undo, restart, hasProgress, totalLevels } = useSokoban();
+  const {
+    index,
+    level,
+    levelPacks,
+    state,
+    move,
+    next,
+    nextLevel,
+    previousLevel,
+    loadLevel,
+    undo,
+    restart,
+    hasProgress,
+    totalLevels,
+  } = useSokoban();
   const {
     playCratePush,
     playCrateDocked,
@@ -116,15 +131,21 @@ function Game() {
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
   const [isHelpModalOpen, setIsHelpModalOpen] = React.useState(false);
   const [isSfxModalOpen, setIsSfxModalOpen] = React.useState(false);
-  const isAuxModalOpen = isHelpModalOpen || isSfxModalOpen || isMenuOpen;
+  const [isLevelSelectorOpen, setIsLevelSelectorOpen] = React.useState(false);
+  const isAuxModalOpen = isHelpModalOpen || isSfxModalOpen || isMenuOpen || isLevelSelectorOpen;
 
-  type PendingAction = "restart" | "previous" | "next" | null;
+  type PendingAction =
+    | { type: "restart" }
+    | { type: "previous" }
+    | { type: "next" }
+    | { type: "select-level"; levelId: string }
+    | null;
   const [pendingAction, setPendingAction] = React.useState<PendingAction>(null);
   const isConfirmationDialogOpen = pendingAction !== null;
 
   const executePendingAction = React.useCallback(
     (action: Exclude<PendingAction, null>) => {
-      switch (action) {
+      switch (action.type) {
         case "restart":
           restart();
           break;
@@ -134,39 +155,65 @@ function Game() {
         case "next":
           nextLevel();
           break;
+        case "select-level":
+          loadLevel(action.levelId);
+          break;
       }
     },
-    [nextLevel, previousLevel, restart]
+    [loadLevel, nextLevel, previousLevel, restart]
   );
 
   const onRequestRestart = React.useCallback(() => {
     if (state !== State.playing) return;
 
     if (!hasProgress) {
-      executePendingAction("restart");
+      executePendingAction({ type: "restart" });
       return;
     }
 
-    setPendingAction("restart");
+    setPendingAction({ type: "restart" });
   }, [executePendingAction, hasProgress, state]);
 
   const onRequestPreviousLevel = React.useCallback(() => {
     if (state !== State.playing || !hasProgress) {
-      executePendingAction("previous");
+      executePendingAction({ type: "previous" });
       return;
     }
 
-    setPendingAction("previous");
+    setPendingAction({ type: "previous" });
   }, [executePendingAction, hasProgress, state]);
 
   const onRequestNextLevel = React.useCallback(() => {
     if (state !== State.playing || !hasProgress) {
-      executePendingAction("next");
+      executePendingAction({ type: "next" });
       return;
     }
 
-    setPendingAction("next");
+    setPendingAction({ type: "next" });
   }, [executePendingAction, hasProgress, state]);
+
+  const onRequestLoadLevel = React.useCallback(
+    (levelId: string) => {
+      setIsLevelSelectorOpen(false);
+
+      if (level.levelId === levelId) {
+        return;
+      }
+
+      const pendingSelectionAction: Exclude<PendingAction, null> = {
+        type: "select-level",
+        levelId,
+      };
+
+      if (state !== State.playing || !hasProgress) {
+        executePendingAction(pendingSelectionAction);
+        return;
+      }
+
+      setPendingAction(pendingSelectionAction);
+    },
+    [executePendingAction, hasProgress, level.levelId, state]
+  );
 
   const shouldUseHoldRepeat = React.useCallback(
     () => !(state === State.playing && hasProgress),
@@ -199,6 +246,10 @@ function Game() {
 
   const onToggleMenu = React.useCallback(() => {
     setIsMenuOpen((current) => !current);
+  }, []);
+
+  const onOpenLevelSelector = React.useCallback(() => {
+    setIsLevelSelectorOpen(true);
   }, []);
 
   const onCloseMenu = React.useCallback(() => {
@@ -271,7 +322,7 @@ function Game() {
   }, [playLevelComplete, state]);
 
   const confirmationDialog = React.useMemo(() => {
-    switch (pendingAction) {
+    switch (pendingAction?.type) {
       case "restart":
         return {
           title: "Restart level?",
@@ -292,6 +343,13 @@ function Game() {
           ariaLabel: "Switch to next level confirmation",
           warningText: "Switching levels now will erase your progress on this level.",
           confirmLabel: "Go to Next Level",
+        };
+      case "select-level":
+        return {
+          title: "Switch level?",
+          ariaLabel: "Switch to selected level confirmation",
+          warningText: "Switching levels now will erase your progress on this level.",
+          confirmLabel: "Go to Selected Level",
         };
       default:
         return null;
@@ -398,6 +456,15 @@ function Game() {
         return;
       }
 
+      if (isLevelSelectorOpen) {
+        if (event.code === "Escape") {
+          setIsLevelSelectorOpen(false);
+        }
+
+        event.preventDefault();
+        return;
+      }
+
       if (isAuxModalOpen) {
         event.preventDefault();
         return;
@@ -478,7 +545,15 @@ function Game() {
               <span className={style.levelPickerChevron} aria-hidden="true">&lsaquo;</span>
             </button>
 
-            <div className={style.levelNumber}>Level {index + 1} / {levelCount}</div>
+            <button
+              type="button"
+              className={`${style.levelNumber} ${style.levelPickerLevelButton}`}
+              aria-label="Open level selector"
+              title="Open level selector"
+              onClick={onOpenLevelSelector}
+            >
+              Level {index + 1} / {levelCount}
+            </button>
 
             <button
               type="button"
@@ -541,6 +616,14 @@ function Game() {
         open={isHelpModalOpen}
         showTrigger={false}
         onOpenChange={setIsHelpModalOpen}
+      />
+
+      <LevelSelectorModal
+        open={isLevelSelectorOpen}
+        onOpenChange={setIsLevelSelectorOpen}
+        levelPacks={levelPacks}
+        currentLevelId={level.levelId}
+        onSelectLevel={onRequestLoadLevel}
       />
 
       {isConfirmationDialogOpen && confirmationDialog && (

--- a/src/components/level-selector-modal.tsx
+++ b/src/components/level-selector-modal.tsx
@@ -6,7 +6,6 @@ type LevelSelectorModalProps = {
     open: boolean;
     onOpenChange: (open: boolean) => void;
     levelPacks: LevelPack[];
-    currentLevelId: string;
     onSelectLevel: (levelId: string) => void;
 };
 
@@ -14,7 +13,6 @@ function LevelSelectorModal({
     open,
     onOpenChange,
     levelPacks,
-    currentLevelId,
     onSelectLevel,
 }: LevelSelectorModalProps) {
     if (!open) {
@@ -30,13 +28,7 @@ function LevelSelectorModal({
         >
             <div className={style.levelSelector}>
                 {levelPacks.map((pack) => {
-                    const currentPackLevelIndex = pack.levels.findIndex(
-                        (packLevel) => packLevel.levelId === currentLevelId
-                    );
-                    const currentPackMeta =
-                        currentPackLevelIndex >= 0
-                            ? `Level ${currentPackLevelIndex + 1} / ${pack.levels.length}`
-                            : `${pack.levels.length} levels`;
+                    const currentPackMeta = `${pack.levels.length} levels available`;
 
                     return (
                         <section className={style.levelSelectorPack} key={pack.packId}>
@@ -59,29 +51,6 @@ function LevelSelectorModal({
                                 >
                                     Play Pack
                                 </button>
-                            </div>
-
-                            {pack.description && (
-                                <p className={style.levelSelectorPackDescription}>{pack.description}</p>
-                            )}
-
-                            <div className={style.levelSelectorLevelGrid}>
-                                {pack.levels.map((packLevel, index) => {
-                                    const isCurrentLevel = packLevel.levelId === currentLevelId;
-                                    return (
-                                        <button
-                                            type="button"
-                                            key={packLevel.levelId}
-                                            className={`${style.levelSelectorLevelButton} ${isCurrentLevel ? style.levelSelectorLevelButtonActive : ""}`}
-                                            onClick={() => onSelectLevel(packLevel.levelId)}
-                                            aria-current={isCurrentLevel ? "true" : undefined}
-                                            aria-label={`Open ${pack.title} level ${index + 1}: ${packLevel.name}`}
-                                        >
-                                            <span className={style.levelSelectorLevelIndex}>{index + 1}</span>
-                                            <span className={style.levelSelectorLevelName}>{packLevel.name}</span>
-                                        </button>
-                                    );
-                                })}
                             </div>
                         </section>
                     );

--- a/src/components/level-selector-modal.tsx
+++ b/src/components/level-selector-modal.tsx
@@ -40,7 +40,7 @@ function LevelSelectorModal({
 
                                 <button
                                     type="button"
-                                    className={style.levelNavButton}
+                                    className={`${style.levelNavButton} ${style.levelSelectorPackPlayButton}`}
                                     onClick={() => {
                                         if (!pack.levels.length) {
                                             return;

--- a/src/components/level-selector-modal.tsx
+++ b/src/components/level-selector-modal.tsx
@@ -1,0 +1,94 @@
+import type { LevelPack } from "../hooks/levels";
+import { Modal } from "./modal";
+import style from "./sokoban.module.css";
+
+type LevelSelectorModalProps = {
+    open: boolean;
+    onOpenChange: (open: boolean) => void;
+    levelPacks: LevelPack[];
+    currentLevelId: string;
+    onSelectLevel: (levelId: string) => void;
+};
+
+function LevelSelectorModal({
+    open,
+    onOpenChange,
+    levelPacks,
+    currentLevelId,
+    onSelectLevel,
+}: LevelSelectorModalProps) {
+    if (!open) {
+        return null;
+    }
+
+    return (
+        <Modal
+            title="Level Packs"
+            ariaLabel="Level pack selector"
+            onClose={() => onOpenChange(false)}
+            autoFocusCloseButton
+        >
+            <div className={style.levelSelector}>
+                {levelPacks.map((pack) => {
+                    const currentPackLevelIndex = pack.levels.findIndex(
+                        (packLevel) => packLevel.levelId === currentLevelId
+                    );
+                    const currentPackMeta =
+                        currentPackLevelIndex >= 0
+                            ? `Level ${currentPackLevelIndex + 1} / ${pack.levels.length}`
+                            : `${pack.levels.length} levels`;
+
+                    return (
+                        <section className={style.levelSelectorPack} key={pack.packId}>
+                            <div className={style.levelSelectorPackHeader}>
+                                <div>
+                                    <h3 className={style.levelSelectorPackTitle}>{pack.title}</h3>
+                                    <p className={style.levelSelectorPackMeta}>{currentPackMeta}</p>
+                                </div>
+
+                                <button
+                                    type="button"
+                                    className={style.levelNavButton}
+                                    onClick={() => {
+                                        if (!pack.levels.length) {
+                                            return;
+                                        }
+                                        onSelectLevel(pack.levels[0].levelId);
+                                    }}
+                                    disabled={!pack.levels.length}
+                                >
+                                    Play Pack
+                                </button>
+                            </div>
+
+                            {pack.description && (
+                                <p className={style.levelSelectorPackDescription}>{pack.description}</p>
+                            )}
+
+                            <div className={style.levelSelectorLevelGrid}>
+                                {pack.levels.map((packLevel, index) => {
+                                    const isCurrentLevel = packLevel.levelId === currentLevelId;
+                                    return (
+                                        <button
+                                            type="button"
+                                            key={packLevel.levelId}
+                                            className={`${style.levelSelectorLevelButton} ${isCurrentLevel ? style.levelSelectorLevelButtonActive : ""}`}
+                                            onClick={() => onSelectLevel(packLevel.levelId)}
+                                            aria-current={isCurrentLevel ? "true" : undefined}
+                                            aria-label={`Open ${pack.title} level ${index + 1}: ${packLevel.name}`}
+                                        >
+                                            <span className={style.levelSelectorLevelIndex}>{index + 1}</span>
+                                            <span className={style.levelSelectorLevelName}>{packLevel.name}</span>
+                                        </button>
+                                    );
+                                })}
+                            </div>
+                        </section>
+                    );
+                })}
+            </div>
+        </Modal>
+    );
+}
+
+export { LevelSelectorModal };

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -219,8 +219,33 @@
     border: 1px solid var(--border);
     background: color-mix(in srgb, var(--surface) 88%, var(--text) 12%);
     border-radius: 999px;
-    padding: 10px 14px;
+    padding: 8px 14px;
+    min-height: 56px;
+    display: inline-grid;
+    gap: 2px;
+    align-content: center;
+    justify-items: center;
     cursor: pointer;
+}
+
+.levelPickerPackName {
+    font-size: 0.76rem;
+    font-weight: 800;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: var(--accent);
+    white-space: nowrap;
+    max-width: 160px;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.levelPickerLevelNumbers {
+    font-size: 0.72rem;
+    font-weight: 700;
+    color: var(--muted);
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
 }
 
 .levelPickerLevelButton:hover {

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -215,6 +215,23 @@
     white-space: nowrap;
 }
 
+.levelPickerLevelButton {
+    border: 1px solid var(--border);
+    background: color-mix(in srgb, var(--surface) 88%, var(--text) 12%);
+    border-radius: 999px;
+    padding: 10px 14px;
+    cursor: pointer;
+}
+
+.levelPickerLevelButton:hover {
+    border-color: var(--accent);
+}
+
+.levelPickerLevelButton:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
 @keyframes bounce {
     from {
         transform: translateY(0);
@@ -441,9 +458,11 @@
 
 .aboutButton,
 .levelNavButton,
+.levelPickerLevelButton,
 .menuToggleButton,
 .menuDrawerCloseButton,
 .menuItemButton,
+.levelSelectorLevelButton,
 .completionButton,
 .modalCloseButton,
 .themeToggleLabel {
@@ -546,6 +565,93 @@
     align-items: center;
     gap: 10px;
     flex-wrap: wrap;
+}
+
+.levelSelector {
+    display: grid;
+    gap: 12px;
+    max-height: 62dvh;
+    overflow: auto;
+    padding-right: 2px;
+}
+
+.levelSelectorPack {
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    padding: 12px;
+    background: color-mix(in srgb, var(--surface) 90%, var(--text) 10%);
+}
+
+.levelSelectorPackHeader {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 10px;
+    flex-wrap: wrap;
+}
+
+.levelSelectorPackTitle {
+    margin: 0;
+    font-size: 1rem;
+    color: var(--accent);
+}
+
+.levelSelectorPackMeta {
+    margin: 4px 0 0;
+    color: var(--muted);
+    font-size: 0.82rem;
+    font-weight: 700;
+}
+
+.levelSelectorPackDescription {
+    margin: 10px 0 12px;
+    color: var(--muted);
+    line-height: 1.45;
+}
+
+.levelSelectorLevelGrid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(130px, 1fr));
+    gap: 8px;
+}
+
+.levelSelectorLevelButton {
+    border: 1px solid var(--border);
+    background: color-mix(in srgb, var(--surface) 88%, var(--text) 12%);
+    color: var(--foreground);
+    border-radius: 10px;
+    padding: 8px 10px;
+    display: grid;
+    gap: 2px;
+    text-align: left;
+    cursor: pointer;
+}
+
+.levelSelectorLevelButton:hover {
+    border-color: var(--accent);
+}
+
+.levelSelectorLevelButton:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+.levelSelectorLevelButtonActive {
+    border-color: var(--accent);
+    box-shadow: inset 0 0 0 1px color-mix(in srgb, var(--accent) 45%, transparent);
+}
+
+.levelSelectorLevelIndex {
+    font-size: 0.72rem;
+    font-weight: 800;
+    color: var(--muted);
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+}
+
+.levelSelectorLevelName {
+    font-size: 0.9rem;
+    font-weight: 700;
 }
 
 .aboutSection {

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -628,6 +628,10 @@
     font-weight: 700;
 }
 
+.levelSelectorPackPlayButton {
+    align-self: center;
+}
+
 .levelSelectorPackDescription {
     margin: 10px 0 12px;
     color: var(--muted);

--- a/src/hooks/levels.test.ts
+++ b/src/hooks/levels.test.ts
@@ -1,0 +1,60 @@
+import "@testing-library/jest-dom/vitest";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, expect, test } from "vitest";
+import { useLevels } from "./levels";
+
+beforeEach(() => {
+    localStorage.clear();
+});
+
+test("previous/next wrap inside the current pack", () => {
+    const { result } = renderHook(() => useLevels());
+
+    const targetPack = result.current.levelPacks.find((pack) => pack.levels.length > 0);
+    if (!targetPack) {
+        throw new Error("Expected at least one non-empty level pack");
+    }
+
+    const firstLevelId = targetPack.levels[0].levelId;
+    const lastLevelId = targetPack.levels[targetPack.levels.length - 1].levelId;
+
+    act(() => {
+        result.current.loadLevel(firstLevelId);
+    });
+
+    act(() => {
+        result.current.loadPrevious();
+    });
+
+    expect(result.current.level.levelId).toBe(lastLevelId);
+    expect(result.current.level.packId).toBe(targetPack.packId);
+
+    act(() => {
+        result.current.loadNext();
+    });
+
+    expect(result.current.level.levelId).toBe(firstLevelId);
+    expect(result.current.level.packId).toBe(targetPack.packId);
+});
+
+test("selecting another pack changes next/previous scope to that pack", () => {
+    const { result } = renderHook(() => useLevels());
+
+    const nonEmptyPacks = result.current.levelPacks.filter((pack) => pack.levels.length > 0);
+    expect(nonEmptyPacks.length).toBeGreaterThan(1);
+
+    const secondPack = nonEmptyPacks[1];
+    const secondPackFirstLevelId = secondPack.levels[0].levelId;
+    const secondPackLastLevelId = secondPack.levels[secondPack.levels.length - 1].levelId;
+
+    act(() => {
+        result.current.loadLevel(secondPackFirstLevelId);
+    });
+
+    act(() => {
+        result.current.loadPrevious();
+    });
+
+    expect(result.current.level.levelId).toBe(secondPackLastLevelId);
+    expect(result.current.level.packId).toBe(secondPack.packId);
+});

--- a/src/hooks/levels.ts
+++ b/src/hooks/levels.ts
@@ -11,6 +11,14 @@ export type Level = {
   puzzleId: string;
 };
 
+export type LevelPack = {
+  packId: string;
+  title: string;
+  description: string;
+  email: string;
+  levels: Level[];
+};
+
 export interface SokobanLevels {
   Title: string;
   Description: string;
@@ -45,7 +53,16 @@ const prioritizedPackOrder = new Map<string, number>(
 
 type LoadedLevelPack = {
   packId: string;
-  levels: SokobanLevels;
+  title: string;
+  description: string;
+  email: string;
+  levels: SokobanLevel[];
+};
+
+type LoadedLevelData = {
+  levels: Level[];
+  levelPacks: LevelPack[];
+  levelIndexById: Map<string, number>;
 };
 
 function levelPackIdFromPath(path: string): string {
@@ -85,9 +102,12 @@ function generatePuzzleFingerprint(layout: string[]): string {
 function loadLevelPacks(): LoadedLevelPack[] {
   return Object.entries(levelPackModules)
     .sort(([leftPath], [rightPath]) => compareLevelPackPaths(leftPath, rightPath))
-    .map(([path, levels]) => ({
+    .map(([path, levelPack]) => ({
       packId: levelPackIdFromPath(path),
-      levels,
+      title: levelPack.Title || levelPackIdFromPath(path),
+      description: levelPack.Description || "",
+      email: levelPack.Email || "",
+      levels: levelPack.LevelCollection.Level,
     }));
 }
 
@@ -162,10 +182,15 @@ function normalizeIndex(index: number, length: number) {
   return ((index % length) + length) % length;
 }
 
-function loadLevels() {
-  const allLevelPacks = loadLevelPacks();
-  return allLevelPacks.flatMap(({ packId, levels }) =>
-    levels.LevelCollection.Level.map((level, levelIndex) => {
+function loadLevelData(): LoadedLevelData {
+  const loadedLevelPacks = loadLevelPacks();
+  const levels: Level[] = [];
+  const levelPacks: LevelPack[] = [];
+  const levelIndexById = new Map<string, number>();
+
+  loadedLevelPacks.forEach((loadedPack) => {
+    const levelStartIndex = levels.length;
+    const packLevels = loadedPack.levels.map((level, levelIndex) => {
       const width = Number(level.Width);
       const height = Number(level.Height);
 
@@ -178,20 +203,39 @@ function loadLevels() {
       });
 
       return {
-        packId,
-        levelId: levelIdFromParts(packId, levelIndex),
+        packId: loadedPack.packId,
+        levelId: levelIdFromParts(loadedPack.packId, levelIndex),
         puzzleId: generatePuzzleFingerprint(level.L),
         name: level.Id,
         shape: markExteriorVoid(filled),
         width,
         height,
-      };
-    })
-  );
+      } satisfies Level;
+    });
+
+    packLevels.forEach((packLevel, packLevelIndex) => {
+      levelIndexById.set(packLevel.levelId, levelStartIndex + packLevelIndex);
+    });
+
+    levels.push(...packLevels);
+    levelPacks.push({
+      packId: loadedPack.packId,
+      title: loadedPack.title,
+      description: loadedPack.description,
+      email: loadedPack.email,
+      levels: packLevels,
+    });
+  });
+
+  return {
+    levels,
+    levelPacks,
+    levelIndexById,
+  };
 }
 
 export function useLevels() {
-  const [levels] = useState<Level[]>(loadLevels);
+  const [{ levels, levelPacks, levelIndexById }] = useState<LoadedLevelData>(loadLevelData);
   const [index, setIndex] = useState(() => {
     const stored = Number(localStorage.getItem(SOKOBAN_LEVEL_KEY));
     const initial = Number.isFinite(stored) ? stored : 0;
@@ -218,11 +262,28 @@ export function useLevels() {
     updateIndex(-1);
   }, [updateIndex]);
 
+  const loadLevel = useCallback(
+    (levelId: string) => {
+      setIndex((current) => {
+        const nextIndex = levelIndexById.get(levelId);
+        if (nextIndex === undefined) {
+          return current;
+        }
+
+        localStorage.setItem(SOKOBAN_LEVEL_KEY, String(nextIndex));
+        return nextIndex;
+      });
+    },
+    [levelIndexById]
+  );
+
   return {
     index,
     level,
+    levelPacks,
     loadNext,
     loadPrevious,
+    loadLevel,
     totalLevels: levels.length,
   };
 }

--- a/src/hooks/levels.ts
+++ b/src/hooks/levels.ts
@@ -63,6 +63,7 @@ type LoadedLevelData = {
   levels: Level[];
   levelPacks: LevelPack[];
   levelIndexById: Map<string, number>;
+  levelPackRangeById: Map<string, { startIndex: number; endIndex: number }>;
 };
 
 function levelPackIdFromPath(path: string): string {
@@ -187,6 +188,7 @@ function loadLevelData(): LoadedLevelData {
   const levels: Level[] = [];
   const levelPacks: LevelPack[] = [];
   const levelIndexById = new Map<string, number>();
+  const levelPackRangeById = new Map<string, { startIndex: number; endIndex: number }>();
 
   loadedLevelPacks.forEach((loadedPack) => {
     const levelStartIndex = levels.length;
@@ -217,6 +219,11 @@ function loadLevelData(): LoadedLevelData {
       levelIndexById.set(packLevel.levelId, levelStartIndex + packLevelIndex);
     });
 
+    levelPackRangeById.set(loadedPack.packId, {
+      startIndex: levelStartIndex,
+      endIndex: levelStartIndex + packLevels.length - 1,
+    });
+
     levels.push(...packLevels);
     levelPacks.push({
       packId: loadedPack.packId,
@@ -231,11 +238,12 @@ function loadLevelData(): LoadedLevelData {
     levels,
     levelPacks,
     levelIndexById,
+    levelPackRangeById,
   };
 }
 
 export function useLevels() {
-  const [{ levels, levelPacks, levelIndexById }] = useState<LoadedLevelData>(loadLevelData);
+  const [{ levels, levelPacks, levelIndexById, levelPackRangeById }] = useState<LoadedLevelData>(loadLevelData);
   const [index, setIndex] = useState(() => {
     const stored = Number(localStorage.getItem(SOKOBAN_LEVEL_KEY));
     const initial = Number.isFinite(stored) ? stored : 0;
@@ -243,15 +251,39 @@ export function useLevels() {
   });
   const level = useMemo(() => levels[index], [levels, index]);
 
+  const moveIndexWithinActivePack = useCallback(
+    (currentIndex: number, delta: number) => {
+      const currentLevel = levels[currentIndex];
+      if (!currentLevel) {
+        return normalizeIndex(currentIndex + delta, levels.length);
+      }
+
+      const packRange = levelPackRangeById.get(currentLevel.packId);
+      if (!packRange) {
+        return normalizeIndex(currentIndex + delta, levels.length);
+      }
+
+      const packLength = packRange.endIndex - packRange.startIndex + 1;
+      if (packLength <= 0) {
+        return normalizeIndex(currentIndex + delta, levels.length);
+      }
+
+      const currentPackRelativeIndex = currentIndex - packRange.startIndex;
+      const nextPackRelativeIndex = normalizeIndex(currentPackRelativeIndex + delta, packLength);
+      return packRange.startIndex + nextPackRelativeIndex;
+    },
+    [levelPackRangeById, levels]
+  );
+
   const updateIndex = useCallback(
     (delta: number) => {
       setIndex((current) => {
-        const nextIndex = normalizeIndex(current + delta, levels.length);
+        const nextIndex = moveIndexWithinActivePack(current, delta);
         localStorage.setItem(SOKOBAN_LEVEL_KEY, String(nextIndex));
         return nextIndex;
       });
     },
-    [levels.length]
+    [moveIndexWithinActivePack]
   );
 
   const loadNext = useCallback(() => {

--- a/src/hooks/sokoban.test.ts
+++ b/src/hooks/sokoban.test.ts
@@ -41,8 +41,18 @@ test("blocked movement updates player orientation without moving or adding progr
     mockedUseLevels.mockReturnValue({
         index: 0,
         level,
+        levelPacks: [
+            {
+                packId: "test-pack",
+                title: "Test Pack",
+                description: "",
+                email: "",
+                levels: [level],
+            },
+        ],
         loadNext: vi.fn(),
         loadPrevious: vi.fn(),
+        loadLevel: vi.fn(),
         totalLevels: 1,
     });
 

--- a/src/hooks/sokoban.ts
+++ b/src/hooks/sokoban.ts
@@ -55,7 +55,7 @@ function getPlayerPosition<T extends Level>(level: T): Position {
 }
 
 export function useSokoban() {
-  const { index, level, loadNext, loadPrevious, totalLevels } = useLevels();
+  const { index, level, levelPacks, loadNext, loadPrevious, loadLevel: loadLevelById, totalLevels } = useLevels();
   const [state, setState] = useState<State>(State.playing);
   const [hasProgress, setHasProgress] = useState(false);
   const initboard = useCallback(
@@ -168,6 +168,15 @@ export function useSokoban() {
     setHasProgress(false);
   }, [loadPrevious]);
 
+  const loadLevel = useCallback(
+    (levelId: string) => {
+      loadLevelById(levelId);
+      setState(State.playing);
+      setHasProgress(false);
+    },
+    [loadLevelById]
+  );
+
   const undo = useCallback(() => {
     if (state === State.playing && board.length > 1) {
       setBoard(board.slice(0, -1));
@@ -184,7 +193,7 @@ export function useSokoban() {
   }, [state, initboard]);
 
   useEffect(() => {
-    if (board[0].name !== level.name) {
+    if (board[0].levelId !== level.levelId) {
       setBoard(initboard());
       setHasProgress(false);
     }
@@ -193,12 +202,14 @@ export function useSokoban() {
   return {
     index,
     level: board[board.length - 1],
+    levelPacks,
     totalLevels,
     state,
     move,
     next,
     nextLevel,
     previousLevel,
+    loadLevel,
     undo,
     restart,
     hasProgress,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite';
+import { defineConfig } from 'vitest/config';
 import react from '@vitejs/plugin-react';
 import packageJson from './package.json';
 
@@ -7,5 +7,9 @@ export default defineConfig({
     base: './',
     define: {
         '__APP_VERSION__': JSON.stringify(packageJson.version),
-    }
+    },
+    test: {
+        testTimeout: 15000,
+        hookTimeout: 15000,
+    },
 });


### PR DESCRIPTION
### Description
This Pull Request implements a Level Pack Selection UI. The game has transitioned from a single, continuous flat list of 490+ levels to a segmented, pack-aware structure. Users can now open a modal to browse available level packs and load them directly. Gameplay navigation logic has been overhauled to respect pack boundaries.

### Key Changes
* **Level Selector Modal:** Added the `LevelSelectorModal` component, providing a scrollable interface for users to select which level pack they want to play. Integrated this directly into the main `Game` component header.
* **Pack-Aware Navigation:** Implemented `levelPackRangeById` state management to track the exact start and end indices of each pack. The `useLevels` and `useSokoban` hooks were updated to restrict "Next Level" and "Previous Level" actions so players do not accidentally bleed into a different pack.
* **Header UI Updates:** Overhauled the top navigation bar to display the active pack name alongside a localized level index, replacing the global index format. 
* **End-of-Pack Completion State:** Updated the completion overlay logic to detect when the final level of the current pack is solved. The overlay now displays a dedicated "Level Pack Complete!" message, prompting the user to switch to a new pack via the selector.
* **Styling and Polish:** Centered and refined button alignments within the modal and top bar picker for a cleaner presentation.
* **Test Coverage:** Added comprehensive unit tests verifying the new modal interactions, proper rendering of the pack-aware context, and strict boundary enforcement for previous/next level navigation.