### PR TITLE
feat: implement persistent statistics and performance tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,14 @@ Click the [**Latest Release**](https://github.com/hubertbanas/sokoban/releases/l
 - `Escape`: Restart current level
 - `[` / `]`: Previous / Next level
 
+## Statistics
+
+- The game UI shows `Level Best` (best moves/time for the current level entry).
+- Internally, the stats model stores both `levelId` and `puzzleId` records:
+	- `levelId` is used for player-facing per-level progress and bests.
+	- `puzzleId` is retained for forward compatibility in case future packs reuse the same puzzle layout across different levels.
+- In the current bundled packs, puzzle layouts are unique, so level and puzzle records are effectively identical today.
+
 ## More Information
 
 - More screenshots: [Screenshots](docs/screenshots.md)

--- a/README.md
+++ b/README.md
@@ -31,7 +31,8 @@ Click the [**Latest Release**](https://github.com/hubertbanas/sokoban/releases/l
 
 ## Statistics
 
-- The game UI shows `Level Best` (best moves/time for the current level entry).
+- The game UI can show `Level Best` (best moves/time for the current level entry) via a menu toggle.
+- `Menu -> Show Level Best` is off by default to keep the HUD minimal.
 - Internally, the stats model stores both `levelId` and `puzzleId` records:
 	- `levelId` is used for player-facing per-level progress and bests.
 	- `puzzleId` is retained for forward compatibility in case future packs reuse the same puzzle layout across different levels.

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Click the [**Latest Release**](https://github.com/hubertbanas/sokoban/releases/l
 
 ## Statistics
 
+- The HUD always shows a realtime `Current Run` status with current moves and time spent on the level.
 - The game UI can show `Level Best` (best moves/time for the current level entry) via a menu toggle.
 - `Menu -> Show Level Best` is off by default to keep the HUD minimal.
 - Internally, the stats model stores both `levelId` and `puzzleId` records:

--- a/README.md
+++ b/README.md
@@ -31,9 +31,11 @@ Click the [**Latest Release**](https://github.com/hubertbanas/sokoban/releases/l
 
 ## Statistics
 
-- The HUD always shows a realtime `Current Run` status with current moves and time spent on the level.
-- The game UI can show `Level Best` (best moves/time for the current level entry) via a menu toggle.
-- `Menu -> Show Level Best` is off by default to keep the HUD minimal.
+- The game UI can show play statistics via a single menu toggle.
+- `Menu -> Show Play Stats` is off by default to keep the HUD minimal.
+- When enabled, the HUD shows:
+	- `Current Run` with live move count and time spent on the current level.
+	- `Level Best` (best moves/time for the current level entry).
 - Internally, the stats model stores both `levelId` and `puzzleId` records:
 	- `levelId` is used for player-facing per-level progress and bests.
 	- `puzzleId` is retained for forward compatibility in case future packs reuse the same puzzle layout across different levels.

--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -574,6 +574,20 @@ test("hides play stats UI when toggle is off by default", () => {
   expect(screen.queryByText("Level Best: No record yet")).not.toBeInTheDocument();
 });
 
+test("keeps completion dialog play stats hidden when toggle is off", () => {
+  const level = buildLevel();
+  mockSokoban({ state: State.playing, level });
+
+  const { rerender } = render(<Game />);
+
+  mockSokoban({ state: State.completed, level });
+  rerender(<Game />);
+
+  const completionDialog = screen.getByRole("dialog", { name: /level completed/i });
+  expect(within(completionDialog).queryByText(/^Current Run:/)).not.toBeInTheDocument();
+  expect(within(completionDialog).queryByText(/^Level Best:/)).not.toBeInTheDocument();
+});
+
 test("renders current run and level best placeholders when play stats toggle is enabled", () => {
   mockSokoban({ state: State.playing });
 
@@ -582,6 +596,19 @@ test("renders current run and level best placeholders when play stats toggle is 
 
   expect(screen.getByText("Current Run: 0 moves in 0:00")).toBeInTheDocument();
   expect(screen.getByText("Level Best: No record yet")).toBeInTheDocument();
+});
+
+test("hides both play stats lines after disabling the toggle", () => {
+  mockSokoban({ state: State.playing });
+
+  render(<Game />);
+  setPlayStatsVisibility(true);
+  expect(screen.getByText("Current Run: 0 moves in 0:00")).toBeInTheDocument();
+  expect(screen.getByText("Level Best: No record yet")).toBeInTheDocument();
+
+  setPlayStatsVisibility(false);
+  expect(screen.queryByText("Current Run: 0 moves in 0:00")).not.toBeInTheDocument();
+  expect(screen.queryByText("Level Best: No record yet")).not.toBeInTheDocument();
 });
 
 test("renders realtime current run status from useSokoban", () => {

--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -206,6 +206,22 @@ function createMockGameSounds(overrides: Partial<ReturnType<typeof useGameSounds
   };
 }
 
+function setLevelBestVisibility(enabled: boolean) {
+  fireEvent.click(screen.getByRole("button", { name: /open menu/i }));
+  const menuDialog = screen.getByRole("dialog", { name: /game menu/i });
+  const toggle = screen.getByRole("checkbox", { name: /level best stats/i });
+
+  if (!(toggle instanceof HTMLInputElement)) {
+    throw new Error("Expected level best toggle to be an input element");
+  }
+
+  if (toggle.checked !== enabled) {
+    fireEvent.click(toggle);
+  }
+
+  fireEvent.click(within(menuDialog).getByRole("button", { name: /close menu/i }));
+}
+
 beforeAll(() => {
   class ResizeObserverMock {
     observe() { }
@@ -547,13 +563,21 @@ test("displays completion popup when level is completed", () => {
   expect(screen.getByTestId("mobile-controls")).toBeInTheDocument();
 });
 
-test("renders no-record placeholders when best stats are unavailable", () => {
+test("hides level best UI when toggle is off by default", () => {
   mockSokoban({ state: State.playing });
 
   render(<Game />);
 
+  expect(screen.queryByText("Level Best: No record yet")).not.toBeInTheDocument();
+});
+
+test("renders no-record placeholders when level best toggle is enabled", () => {
+  mockSokoban({ state: State.playing });
+
+  render(<Game />);
+  setLevelBestVisibility(true);
+
   expect(screen.getByText("Level Best: No record yet")).toBeInTheDocument();
-  expect(screen.queryByText(/^Puzzle Best:/)).not.toBeInTheDocument();
 });
 
 test("renders level best from useStats", () => {
@@ -590,6 +614,7 @@ test("renders level best from useStats", () => {
   mockSokoban({ state: State.playing, level });
 
   render(<Game />);
+  setLevelBestVisibility(true);
 
   expect(screen.getByText("Level Best: 9 moves in 0:13")).toBeInTheDocument();
   expect(screen.queryByText(/^Puzzle Best:/)).not.toBeInTheDocument();
@@ -626,9 +651,13 @@ test("shows level best inside completion dialog", () => {
       },
     })
   );
-  mockSokoban({ state: State.completed, level });
+  mockSokoban({ state: State.playing, level });
 
-  render(<Game />);
+  const { rerender } = render(<Game />);
+  setLevelBestVisibility(true);
+
+  mockSokoban({ state: State.completed, level });
+  rerender(<Game />);
 
   const completionDialog = screen.getByRole("dialog", { name: /level completed/i });
   expect(within(completionDialog).getByText("Level Best: 1 move in 0:02")).toBeInTheDocument();

--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -208,13 +208,13 @@ function createMockGameSounds(overrides: Partial<ReturnType<typeof useGameSounds
   };
 }
 
-function setLevelBestVisibility(enabled: boolean) {
+function setPlayStatsVisibility(enabled: boolean) {
   fireEvent.click(screen.getByRole("button", { name: /open menu/i }));
   const menuDialog = screen.getByRole("dialog", { name: /game menu/i });
-  const toggle = screen.getByRole("checkbox", { name: /level best stats/i });
+  const toggle = screen.getByRole("checkbox", { name: /play stats/i });
 
   if (!(toggle instanceof HTMLInputElement)) {
-    throw new Error("Expected level best toggle to be an input element");
+    throw new Error("Expected play stats toggle to be an input element");
   }
 
   if (toggle.checked !== enabled) {
@@ -565,20 +565,20 @@ test("displays completion popup when level is completed", () => {
   expect(screen.getByTestId("mobile-controls")).toBeInTheDocument();
 });
 
-test("hides level best UI when toggle is off by default", () => {
+test("hides play stats UI when toggle is off by default", () => {
   mockSokoban({ state: State.playing });
 
   render(<Game />);
 
-  expect(screen.getByText("Current Run: 0 moves in 0:00")).toBeInTheDocument();
+  expect(screen.queryByText("Current Run: 0 moves in 0:00")).not.toBeInTheDocument();
   expect(screen.queryByText("Level Best: No record yet")).not.toBeInTheDocument();
 });
 
-test("renders no-record placeholders when level best toggle is enabled", () => {
+test("renders current run and level best placeholders when play stats toggle is enabled", () => {
   mockSokoban({ state: State.playing });
 
   render(<Game />);
-  setLevelBestVisibility(true);
+  setPlayStatsVisibility(true);
 
   expect(screen.getByText("Current Run: 0 moves in 0:00")).toBeInTheDocument();
   expect(screen.getByText("Level Best: No record yet")).toBeInTheDocument();
@@ -592,6 +592,7 @@ test("renders realtime current run status from useSokoban", () => {
   });
 
   render(<Game />);
+  setPlayStatsVisibility(true);
 
   expect(screen.getByText("Current Run: 12 moves in 1:14")).toBeInTheDocument();
 });
@@ -630,7 +631,7 @@ test("renders level best from useStats", () => {
   mockSokoban({ state: State.playing, level });
 
   render(<Game />);
-  setLevelBestVisibility(true);
+  setPlayStatsVisibility(true);
 
   expect(screen.getByText("Level Best: 9 moves in 0:13")).toBeInTheDocument();
   expect(screen.queryByText(/^Puzzle Best:/)).not.toBeInTheDocument();
@@ -670,7 +671,7 @@ test("shows level best inside completion dialog", () => {
   mockSokoban({ state: State.playing, level });
 
   const { rerender } = render(<Game />);
-  setLevelBestVisibility(true);
+  setPlayStatsVisibility(true);
 
   mockSokoban({ state: State.completed, level });
   rerender(<Game />);

--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -547,6 +547,94 @@ test("displays completion popup when level is completed", () => {
   expect(screen.getByTestId("mobile-controls")).toBeInTheDocument();
 });
 
+test("renders no-record placeholders when best stats are unavailable", () => {
+  mockSokoban({ state: State.playing });
+
+  render(<Game />);
+
+  expect(screen.getByText("Level Best: No record yet")).toBeInTheDocument();
+  expect(screen.queryByText(/^Puzzle Best:/)).not.toBeInTheDocument();
+});
+
+test("renders level best from useStats", () => {
+  const level = buildLevel();
+
+  mockedUseStats.mockReturnValue(
+    createMockStats({
+      stats: {
+        version: 1,
+        updatedAt: 1700,
+        progression: {
+          [level.levelId]: {
+            playCount: 3,
+            completionCount: 2,
+            isCompleted: true,
+            lastPlayedAt: 1500,
+            lastCompletedAt: 1600,
+            bestMovesInLevel: 9,
+            bestTimeMsInLevel: 13_000,
+          },
+        },
+        records: {
+          [level.puzzleId]: {
+            bestMoves: 8,
+            bestTimeMs: 11_000,
+            solveCount: 5,
+            firstSolvedAt: 1200,
+            lastSolvedAt: 1700,
+          },
+        },
+      },
+    })
+  );
+  mockSokoban({ state: State.playing, level });
+
+  render(<Game />);
+
+  expect(screen.getByText("Level Best: 9 moves in 0:13")).toBeInTheDocument();
+  expect(screen.queryByText(/^Puzzle Best:/)).not.toBeInTheDocument();
+});
+
+test("shows level best inside completion dialog", () => {
+  const level = buildLevel();
+
+  mockedUseStats.mockReturnValue(
+    createMockStats({
+      stats: {
+        version: 1,
+        updatedAt: 1700,
+        progression: {
+          [level.levelId]: {
+            playCount: 1,
+            completionCount: 1,
+            isCompleted: true,
+            lastPlayedAt: 1600,
+            lastCompletedAt: 1700,
+            bestMovesInLevel: 1,
+            bestTimeMsInLevel: 2_000,
+          },
+        },
+        records: {
+          [level.puzzleId]: {
+            bestMoves: 1,
+            bestTimeMs: 2_000,
+            solveCount: 1,
+            firstSolvedAt: 1700,
+            lastSolvedAt: 1700,
+          },
+        },
+      },
+    })
+  );
+  mockSokoban({ state: State.completed, level });
+
+  render(<Game />);
+
+  const completionDialog = screen.getByRole("dialog", { name: /level completed/i });
+  expect(within(completionDialog).getByText("Level Best: 1 move in 0:02")).toBeInTheDocument();
+  expect(within(completionDialog).queryByText(/^Puzzle Best:/)).not.toBeInTheDocument();
+});
+
 test("displays pack-complete message on the last level of the current pack", () => {
   const levelPacks = buildLevelPacks();
   mockSokoban({

--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -9,6 +9,7 @@ import { Block } from "./hooks/levels";
 import { Direction, State, useSokoban, type MoveOutcome } from "./hooks/sokoban";
 import { useKeyBoard } from "./hooks/keyboard";
 import { useGameSounds } from "./hooks/useGameSounds";
+import { useStats } from "./hooks/useStats";
 import style from "./components/sokoban.module.css";
 
 vi.mock("./hooks/keyboard", () => ({
@@ -59,6 +60,10 @@ vi.mock("./hooks/useGameSounds", () => ({
   useGameSounds: vi.fn(),
 }));
 
+vi.mock("./hooks/useStats", () => ({
+  useStats: vi.fn(),
+}));
+
 vi.mock("./hooks/sokoban", () => {
   const Direction = {
     Left: 0,
@@ -81,6 +86,7 @@ vi.mock("./hooks/sokoban", () => {
 const mockedUseSokoban = vi.mocked(useSokoban);
 const mockedUseKeyBoard = vi.mocked(useKeyBoard);
 const mockedUseGameSounds = vi.mocked(useGameSounds);
+const mockedUseStats = vi.mocked(useStats);
 const cssText = readFileSync(resolve(process.cwd(), "src/components/sokoban.module.css"), "utf-8");
 
 function hasUserSelectNone(className: string) {
@@ -151,6 +157,7 @@ function mockSokoban(overrides: Partial<ReturnType<typeof useSokoban>> = {}) {
     totalLevels: 500,
     level: buildLevel(),
     levelPacks: buildLevelPacks(),
+    completionMetrics: null,
     state: State.playing,
     hasProgress: false,
     move: vi.fn(),
@@ -165,6 +172,20 @@ function mockSokoban(overrides: Partial<ReturnType<typeof useSokoban>> = {}) {
   const value = { ...defaults, ...overrides };
   mockedUseSokoban.mockReturnValue(value);
   return value;
+}
+
+function createMockStats(overrides: Partial<ReturnType<typeof useStats>> = {}): ReturnType<typeof useStats> {
+  return {
+    stats: {
+      version: 1,
+      updatedAt: 0,
+      progression: {},
+      records: {},
+    },
+    saveLevelResult: vi.fn(),
+    clearStats: vi.fn(),
+    ...overrides,
+  };
 }
 
 function createMockGameSounds(overrides: Partial<ReturnType<typeof useGameSounds>> = {}) {
@@ -203,7 +224,9 @@ beforeEach(() => {
   mockedUseSokoban.mockReset();
   mockedUseKeyBoard.mockReset();
   mockedUseGameSounds.mockReset();
+  mockedUseStats.mockReset();
   mockedUseGameSounds.mockReturnValue(createMockGameSounds());
+  mockedUseStats.mockReturnValue(createMockStats());
 });
 
 afterEach(() => {
@@ -1007,6 +1030,85 @@ test("plays level complete sound when state changes to completed", () => {
   rerender(<Game />);
 
   expect(playLevelComplete).toHaveBeenCalledTimes(1);
+});
+
+test("saves completion metrics when state changes to completed", () => {
+  const saveLevelResult = vi.fn();
+
+  mockedUseStats.mockReturnValue(
+    createMockStats({
+      saveLevelResult,
+    })
+  );
+
+  const completedLevel = buildLevel();
+  const completionMetrics = {
+    moves: 12,
+    timeMs: 3456,
+  };
+
+  mockSokoban({ state: State.playing, level: completedLevel, completionMetrics: null });
+
+  const { rerender } = render(<Game />);
+  expect(saveLevelResult).not.toHaveBeenCalled();
+
+  mockSokoban({ state: State.completed, level: completedLevel, completionMetrics });
+  rerender(<Game />);
+
+  expect(saveLevelResult).toHaveBeenCalledTimes(1);
+  expect(saveLevelResult).toHaveBeenCalledWith({
+    levelId: completedLevel.levelId,
+    puzzleId: completedLevel.puzzleId,
+    moves: completionMetrics.moves,
+    timeMs: completionMetrics.timeMs,
+  });
+});
+
+test("saves completion metrics only once per completion transition", () => {
+  const saveLevelResult = vi.fn();
+
+  mockedUseStats.mockReturnValue(
+    createMockStats({
+      saveLevelResult,
+    })
+  );
+
+  const completedLevel = buildLevel();
+  const completionMetrics = {
+    moves: 7,
+    timeMs: 1234,
+  };
+
+  mockSokoban({ state: State.playing, level: completedLevel, completionMetrics: null });
+  const { rerender } = render(<Game />);
+
+  mockSokoban({ state: State.completed, level: completedLevel, completionMetrics });
+  rerender(<Game />);
+
+  mockSokoban({ state: State.completed, level: completedLevel, completionMetrics });
+  rerender(<Game />);
+
+  expect(saveLevelResult).toHaveBeenCalledTimes(1);
+});
+
+test("does not save completion metrics when they are unavailable", () => {
+  const saveLevelResult = vi.fn();
+
+  mockedUseStats.mockReturnValue(
+    createMockStats({
+      saveLevelResult,
+    })
+  );
+
+  const completedLevel = buildLevel();
+
+  mockSokoban({ state: State.playing, level: completedLevel, completionMetrics: null });
+  const { rerender } = render(<Game />);
+
+  mockSokoban({ state: State.completed, level: completedLevel, completionMetrics: null });
+  rerender(<Game />);
+
+  expect(saveLevelResult).not.toHaveBeenCalled();
 });
 
 test("restart confirmation opens with Escape when progress exists", () => {

--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -157,6 +157,8 @@ function mockSokoban(overrides: Partial<ReturnType<typeof useSokoban>> = {}) {
     totalLevels: 500,
     level: buildLevel(),
     levelPacks: buildLevelPacks(),
+    moveCount: 0,
+    elapsedTimeMs: 0,
     completionMetrics: null,
     state: State.playing,
     hasProgress: false,
@@ -568,6 +570,7 @@ test("hides level best UI when toggle is off by default", () => {
 
   render(<Game />);
 
+  expect(screen.getByText("Current Run: 0 moves in 0:00")).toBeInTheDocument();
   expect(screen.queryByText("Level Best: No record yet")).not.toBeInTheDocument();
 });
 
@@ -577,7 +580,20 @@ test("renders no-record placeholders when level best toggle is enabled", () => {
   render(<Game />);
   setLevelBestVisibility(true);
 
+  expect(screen.getByText("Current Run: 0 moves in 0:00")).toBeInTheDocument();
   expect(screen.getByText("Level Best: No record yet")).toBeInTheDocument();
+});
+
+test("renders realtime current run status from useSokoban", () => {
+  mockSokoban({
+    state: State.playing,
+    moveCount: 12,
+    elapsedTimeMs: 74_500,
+  });
+
+  render(<Game />);
+
+  expect(screen.getByText("Current Run: 12 moves in 1:14")).toBeInTheDocument();
 });
 
 test("renders level best from useStats", () => {
@@ -660,6 +676,7 @@ test("shows level best inside completion dialog", () => {
   rerender(<Game />);
 
   const completionDialog = screen.getByRole("dialog", { name: /level completed/i });
+  expect(within(completionDialog).getByText("Current Run: 0 moves in 0:00")).toBeInTheDocument();
   expect(within(completionDialog).getByText("Level Best: 1 move in 0:02")).toBeInTheDocument();
   expect(within(completionDialog).queryByText(/^Puzzle Best:/)).not.toBeInTheDocument();
 });

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -15,6 +15,17 @@ import { styleFrom, styleDirection } from "./utils/block-styles";
 import { Modal } from "./components/modal";
 import { LevelSelectorModal } from "./components/level-selector-modal";
 
+function formatElapsedTime(timeMs: number): string {
+  const totalSeconds = Math.max(0, Math.floor(timeMs / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${String(seconds).padStart(2, "0")}`;
+}
+
+function formatMoveLabel(moves: number): string {
+  return `${moves} ${moves === 1 ? "move" : "moves"}`;
+}
+
 function useHoldToRepeat(
   action: () => void,
   delay = 320,
@@ -114,7 +125,7 @@ function Game() {
     hasProgress,
     totalLevels,
   } = useSokoban();
-  const { saveLevelResult } = useStats();
+  const { stats, saveLevelResult } = useStats();
   const {
     playCratePush,
     playCrateDocked,
@@ -323,6 +334,9 @@ function Game() {
       playLevelComplete();
 
       if (completionMetrics) {
+        // Keep dual-key persistence even though the UI currently shows only Level Best.
+        // `levelId` powers player-facing per-level stats, while `puzzleId` keeps
+        // cross-level puzzle records for future packs that may reuse layouts.
         saveLevelResult({
           levelId: level.levelId,
           puzzleId: level.puzzleId,
@@ -457,6 +471,14 @@ function Game() {
     const currentPackLevelNumber = currentPackLevelIndex >= 0 ? currentPackLevelIndex + 1 : 1;
     return `${currentPackLevelNumber} / ${currentPack.levels.length}`;
   }, [currentPack, currentPackLevelIndex, index, levelCount]);
+  const levelBest = stats.progression[level.levelId];
+  const levelBestText = React.useMemo(() => {
+    if (!levelBest || levelBest.bestMovesInLevel === null || levelBest.bestTimeMsInLevel === null) {
+      return "Level Best: No record yet";
+    }
+
+    return `Level Best: ${formatMoveLabel(levelBest.bestMovesInLevel)} in ${formatElapsedTime(levelBest.bestTimeMsInLevel)}`;
+  }, [levelBest]);
 
   useKeyBoard(
     (event) => {
@@ -612,6 +634,10 @@ function Game() {
         <div className={style.topBarSpacer} aria-hidden="true" />
       </header>
 
+      <section className={style.bestStatsBar} aria-label="Best statistics">
+        <p className={style.bestStatsChip}>{levelBestText}</p>
+      </section>
+
       <section className={style.mapArea} aria-label="Sokoban board">
         <div className={style.boardViewport} ref={boardViewportRef}>
           <div className={style.board} style={boardVars}>
@@ -716,6 +742,9 @@ function Game() {
                 return to Level 1 in this pack.
               </p>
             )}
+            <div className={style.completionStats} aria-label="Best records">
+              <p className={style.completionStatsLine}>{levelBestText}</p>
+            </div>
             <button type="button" className={style.completionButton} onClick={next}>
               Continue
             </button>

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -113,6 +113,8 @@ function Game() {
     index,
     level,
     levelPacks,
+    moveCount,
+    elapsedTimeMs,
     completionMetrics,
     state,
     move,
@@ -481,6 +483,10 @@ function Game() {
 
     return `Level Best: ${formatMoveLabel(levelBest.bestMovesInLevel)} in ${formatElapsedTime(levelBest.bestTimeMsInLevel)}`;
   }, [levelBest]);
+  const currentRunText = React.useMemo(
+    () => `Current Run: ${formatMoveLabel(moveCount)} in ${formatElapsedTime(elapsedTimeMs)}`,
+    [elapsedTimeMs, moveCount]
+  );
 
   useKeyBoard(
     (event) => {
@@ -636,11 +642,10 @@ function Game() {
         <div className={style.topBarSpacer} aria-hidden="true" />
       </header>
 
-      {showLevelBest && (
-        <section className={style.bestStatsBar} aria-label="Best statistics">
-          <p className={style.bestStatsChip}>{levelBestText}</p>
-        </section>
-      )}
+      <section className={style.bestStatsBar} aria-label="Play statistics">
+        <p className={style.bestStatsChip}>{currentRunText}</p>
+        {showLevelBest && <p className={style.bestStatsChip}>{levelBestText}</p>}
+      </section>
 
       <section className={style.mapArea} aria-label="Sokoban board">
         <div className={style.boardViewport} ref={boardViewportRef}>
@@ -748,11 +753,10 @@ function Game() {
                 return to Level 1 in this pack.
               </p>
             )}
-            {showLevelBest && (
-              <div className={style.completionStats} aria-label="Best records">
-                <p className={style.completionStatsLine}>{levelBestText}</p>
-              </div>
-            )}
+            <div className={style.completionStats} aria-label="Run and best records">
+              <p className={style.completionStatsLine}>{currentRunText}</p>
+              {showLevelBest && <p className={style.completionStatsLine}>{levelBestText}</p>}
+            </div>
             <button type="button" className={style.completionButton} onClick={next}>
               Continue
             </button>

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -143,6 +143,8 @@ function Game() {
   const confirmButtonRef = React.useRef<HTMLButtonElement | null>(null);
   const [tileSize, setTileSize] = React.useState(24);
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
+  // Level Best is optional HUD info; default off to keep the board area less noisy.
+  const [showLevelBest, setShowLevelBest] = React.useState(false);
   const [isHelpModalOpen, setIsHelpModalOpen] = React.useState(false);
   const [isSfxModalOpen, setIsSfxModalOpen] = React.useState(false);
   const [isLevelSelectorOpen, setIsLevelSelectorOpen] = React.useState(false);
@@ -634,9 +636,11 @@ function Game() {
         <div className={style.topBarSpacer} aria-hidden="true" />
       </header>
 
-      <section className={style.bestStatsBar} aria-label="Best statistics">
-        <p className={style.bestStatsChip}>{levelBestText}</p>
-      </section>
+      {showLevelBest && (
+        <section className={style.bestStatsBar} aria-label="Best statistics">
+          <p className={style.bestStatsChip}>{levelBestText}</p>
+        </section>
+      )}
 
       <section className={style.mapArea} aria-label="Sokoban board">
         <div className={style.boardViewport} ref={boardViewportRef}>
@@ -665,6 +669,8 @@ function Game() {
 
       <HamburgerMenu
         open={isMenuOpen}
+        showLevelBest={showLevelBest}
+        onShowLevelBestChange={setShowLevelBest}
         onClose={onCloseMenu}
         onOpenSfx={onOpenSfxFromMenu}
         onOpenAbout={onOpenAboutFromMenu}
@@ -742,9 +748,11 @@ function Game() {
                 return to Level 1 in this pack.
               </p>
             )}
-            <div className={style.completionStats} aria-label="Best records">
-              <p className={style.completionStatsLine}>{levelBestText}</p>
-            </div>
+            {showLevelBest && (
+              <div className={style.completionStats} aria-label="Best records">
+                <p className={style.completionStatsLine}>{levelBestText}</p>
+              </div>
+            )}
             <button type="button" className={style.completionButton} onClick={next}>
               Continue
             </button>

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -145,8 +145,8 @@ function Game() {
   const confirmButtonRef = React.useRef<HTMLButtonElement | null>(null);
   const [tileSize, setTileSize] = React.useState(24);
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
-  // Level Best is optional HUD info; default off to keep the board area less noisy.
-  const [showLevelBest, setShowLevelBest] = React.useState(false);
+  // Play statistics are optional HUD info; default off to keep the board area less noisy.
+  const [showPlayStats, setShowPlayStats] = React.useState(false);
   const [isHelpModalOpen, setIsHelpModalOpen] = React.useState(false);
   const [isSfxModalOpen, setIsSfxModalOpen] = React.useState(false);
   const [isLevelSelectorOpen, setIsLevelSelectorOpen] = React.useState(false);
@@ -642,10 +642,12 @@ function Game() {
         <div className={style.topBarSpacer} aria-hidden="true" />
       </header>
 
-      <section className={style.bestStatsBar} aria-label="Play statistics">
-        <p className={style.bestStatsChip}>{currentRunText}</p>
-        {showLevelBest && <p className={style.bestStatsChip}>{levelBestText}</p>}
-      </section>
+      {showPlayStats && (
+        <section className={style.bestStatsBar} aria-label="Play statistics">
+          <p className={style.bestStatsChip}>{currentRunText}</p>
+          <p className={style.bestStatsChip}>{levelBestText}</p>
+        </section>
+      )}
 
       <section className={style.mapArea} aria-label="Sokoban board">
         <div className={style.boardViewport} ref={boardViewportRef}>
@@ -674,8 +676,8 @@ function Game() {
 
       <HamburgerMenu
         open={isMenuOpen}
-        showLevelBest={showLevelBest}
-        onShowLevelBestChange={setShowLevelBest}
+        showPlayStats={showPlayStats}
+        onShowPlayStatsChange={setShowPlayStats}
         onClose={onCloseMenu}
         onOpenSfx={onOpenSfxFromMenu}
         onOpenAbout={onOpenAboutFromMenu}
@@ -753,10 +755,12 @@ function Game() {
                 return to Level 1 in this pack.
               </p>
             )}
-            <div className={style.completionStats} aria-label="Run and best records">
-              <p className={style.completionStatsLine}>{currentRunText}</p>
-              {showLevelBest && <p className={style.completionStatsLine}>{levelBestText}</p>}
-            </div>
+            {showPlayStats && (
+              <div className={style.completionStats} aria-label="Run and best records">
+                <p className={style.completionStatsLine}>{currentRunText}</p>
+                <p className={style.completionStatsLine}>{levelBestText}</p>
+              </div>
+            )}
             <button type="button" className={style.completionButton} onClick={next}>
               Continue
             </button>

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -8,6 +8,7 @@ import { useSokoban, Direction, State } from "./hooks/sokoban";
 import { useGameSounds } from "./hooks/useGameSounds";
 import { useKeyBoard } from "./hooks/keyboard";
 import { Block } from "./hooks/levels";
+import { useStats } from "./hooks/useStats";
 import style from "./components/sokoban.module.css";
 import { cn } from "./utils/classnames";
 import { styleFrom, styleDirection } from "./utils/block-styles";
@@ -101,6 +102,7 @@ function Game() {
     index,
     level,
     levelPacks,
+    completionMetrics,
     state,
     move,
     next,
@@ -112,6 +114,7 @@ function Game() {
     hasProgress,
     totalLevels,
   } = useSokoban();
+  const { saveLevelResult } = useStats();
   const {
     playCratePush,
     playCrateDocked,
@@ -314,12 +317,23 @@ function Game() {
   const previousStateRef = React.useRef(state);
 
   React.useEffect(() => {
-    if (state === State.completed && previousStateRef.current !== State.completed) {
+    const didCompleteNow = state === State.completed && previousStateRef.current !== State.completed;
+
+    if (didCompleteNow) {
       playLevelComplete();
+
+      if (completionMetrics) {
+        saveLevelResult({
+          levelId: level.levelId,
+          puzzleId: level.puzzleId,
+          moves: completionMetrics.moves,
+          timeMs: completionMetrics.timeMs,
+        });
+      }
     }
 
     previousStateRef.current = state;
-  }, [playLevelComplete, state]);
+  }, [completionMetrics, level.levelId, level.puzzleId, playLevelComplete, saveLevelResult, state]);
 
   const confirmationDialog = React.useMemo(() => {
     switch (pendingAction?.type) {

--- a/src/components/hamburger-menu.test.tsx
+++ b/src/components/hamburger-menu.test.tsx
@@ -17,7 +17,7 @@ afterEach(() => {
     cleanup();
 });
 
-function renderMenu(open = true) {
+function renderMenu(open = true, showPlayStats = false) {
     const onClose = vi.fn();
     const onShowPlayStatsChange = vi.fn();
     const onOpenSfx = vi.fn();
@@ -26,7 +26,7 @@ function renderMenu(open = true) {
     const view = render(
         <HamburgerMenu
             open={open}
-            showPlayStats={false}
+            showPlayStats={showPlayStats}
             onShowPlayStatsChange={onShowPlayStatsChange}
             onClose={onClose}
             onOpenSfx={onOpenSfx}
@@ -54,6 +54,12 @@ test("renders menu content and version", () => {
     expect(getByRole("button", { name: /sfx settings/i })).toBeInTheDocument();
     expect(getByRole("button", { name: /^about$/i })).toBeInTheDocument();
     expect(getByText(/version\s+1\.2\.3-test/i)).toBeInTheDocument();
+});
+
+test("shows checked play stats toggle with hide aria label when enabled", () => {
+    const { getByRole } = renderMenu(true, true);
+
+    expect(getByRole("checkbox", { name: /hide play stats/i })).toBeChecked();
 });
 
 test("applies open and hidden states based on open prop", () => {

--- a/src/components/hamburger-menu.test.tsx
+++ b/src/components/hamburger-menu.test.tsx
@@ -19,15 +19,15 @@ afterEach(() => {
 
 function renderMenu(open = true) {
     const onClose = vi.fn();
-    const onShowLevelBestChange = vi.fn();
+    const onShowPlayStatsChange = vi.fn();
     const onOpenSfx = vi.fn();
     const onOpenAbout = vi.fn();
 
     const view = render(
         <HamburgerMenu
             open={open}
-            showLevelBest={false}
-            onShowLevelBestChange={onShowLevelBestChange}
+            showPlayStats={false}
+            onShowPlayStatsChange={onShowPlayStatsChange}
             onClose={onClose}
             onOpenSfx={onOpenSfx}
             onOpenAbout={onOpenAbout}
@@ -37,7 +37,7 @@ function renderMenu(open = true) {
     return {
         ...view,
         onClose,
-        onShowLevelBestChange,
+        onShowPlayStatsChange,
         onOpenSfx,
         onOpenAbout,
     };
@@ -49,15 +49,15 @@ test("renders menu content and version", () => {
     expect(getByRole("dialog", { name: /game menu/i })).toBeInTheDocument();
     expect(getByText("Theme")).toBeInTheDocument();
     expect(getByTestId("theme-switcher")).toBeInTheDocument();
-    expect(getByText("Show Level Best")).toBeInTheDocument();
-    expect(getByRole("checkbox", { name: /show level best stats/i })).not.toBeChecked();
+    expect(getByText("Show Play Stats")).toBeInTheDocument();
+    expect(getByRole("checkbox", { name: /show play stats/i })).not.toBeChecked();
     expect(getByRole("button", { name: /sfx settings/i })).toBeInTheDocument();
     expect(getByRole("button", { name: /^about$/i })).toBeInTheDocument();
     expect(getByText(/version\s+1\.2\.3-test/i)).toBeInTheDocument();
 });
 
 test("applies open and hidden states based on open prop", () => {
-    const { rerender, container, onClose, onShowLevelBestChange, onOpenAbout, onOpenSfx } = renderMenu(false);
+    const { rerender, container, onClose, onShowPlayStatsChange, onOpenAbout, onOpenSfx } = renderMenu(false);
 
     let drawer = container.querySelector("#game-menu");
     if (!drawer) {
@@ -77,8 +77,8 @@ test("applies open and hidden states based on open prop", () => {
     rerender(
         <HamburgerMenu
             open
-            showLevelBest={false}
-            onShowLevelBestChange={onShowLevelBestChange}
+            showPlayStats={false}
+            onShowPlayStatsChange={onShowPlayStatsChange}
             onClose={onClose}
             onOpenSfx={onOpenSfx}
             onOpenAbout={onOpenAbout}
@@ -101,7 +101,7 @@ test("applies open and hidden states based on open prop", () => {
 });
 
 test("menu actions call the expected callbacks", () => {
-    const { container, getByRole, onClose, onShowLevelBestChange, onOpenSfx, onOpenAbout } = renderMenu(true);
+    const { container, getByRole, onClose, onShowPlayStatsChange, onOpenSfx, onOpenAbout } = renderMenu(true);
 
     const backdrop = container.querySelector(`.${style.menuBackdrop}`);
     if (!backdrop) {
@@ -110,12 +110,12 @@ test("menu actions call the expected callbacks", () => {
 
     fireEvent.click(backdrop);
     fireEvent.click(getByRole("button", { name: /close menu/i }));
-    fireEvent.click(getByRole("checkbox", { name: /show level best stats/i }));
+    fireEvent.click(getByRole("checkbox", { name: /show play stats/i }));
     fireEvent.click(getByRole("button", { name: /sfx settings/i }));
     fireEvent.click(getByRole("button", { name: /^about$/i }));
 
     expect(onClose).toHaveBeenCalledTimes(2);
-    expect(onShowLevelBestChange).toHaveBeenCalledWith(true);
+    expect(onShowPlayStatsChange).toHaveBeenCalledWith(true);
     expect(onOpenSfx).toHaveBeenCalledTimes(1);
     expect(onOpenAbout).toHaveBeenCalledTimes(1);
 });

--- a/src/components/hamburger-menu.test.tsx
+++ b/src/components/hamburger-menu.test.tsx
@@ -19,12 +19,15 @@ afterEach(() => {
 
 function renderMenu(open = true) {
     const onClose = vi.fn();
+    const onShowLevelBestChange = vi.fn();
     const onOpenSfx = vi.fn();
     const onOpenAbout = vi.fn();
 
     const view = render(
         <HamburgerMenu
             open={open}
+            showLevelBest={false}
+            onShowLevelBestChange={onShowLevelBestChange}
             onClose={onClose}
             onOpenSfx={onOpenSfx}
             onOpenAbout={onOpenAbout}
@@ -34,6 +37,7 @@ function renderMenu(open = true) {
     return {
         ...view,
         onClose,
+        onShowLevelBestChange,
         onOpenSfx,
         onOpenAbout,
     };
@@ -45,13 +49,15 @@ test("renders menu content and version", () => {
     expect(getByRole("dialog", { name: /game menu/i })).toBeInTheDocument();
     expect(getByText("Theme")).toBeInTheDocument();
     expect(getByTestId("theme-switcher")).toBeInTheDocument();
+    expect(getByText("Show Level Best")).toBeInTheDocument();
+    expect(getByRole("checkbox", { name: /show level best stats/i })).not.toBeChecked();
     expect(getByRole("button", { name: /sfx settings/i })).toBeInTheDocument();
     expect(getByRole("button", { name: /^about$/i })).toBeInTheDocument();
     expect(getByText(/version\s+1\.2\.3-test/i)).toBeInTheDocument();
 });
 
 test("applies open and hidden states based on open prop", () => {
-    const { rerender, container, onClose, onOpenAbout, onOpenSfx } = renderMenu(false);
+    const { rerender, container, onClose, onShowLevelBestChange, onOpenAbout, onOpenSfx } = renderMenu(false);
 
     let drawer = container.querySelector("#game-menu");
     if (!drawer) {
@@ -71,6 +77,8 @@ test("applies open and hidden states based on open prop", () => {
     rerender(
         <HamburgerMenu
             open
+            showLevelBest={false}
+            onShowLevelBestChange={onShowLevelBestChange}
             onClose={onClose}
             onOpenSfx={onOpenSfx}
             onOpenAbout={onOpenAbout}
@@ -93,7 +101,7 @@ test("applies open and hidden states based on open prop", () => {
 });
 
 test("menu actions call the expected callbacks", () => {
-    const { container, getByRole, onClose, onOpenSfx, onOpenAbout } = renderMenu(true);
+    const { container, getByRole, onClose, onShowLevelBestChange, onOpenSfx, onOpenAbout } = renderMenu(true);
 
     const backdrop = container.querySelector(`.${style.menuBackdrop}`);
     if (!backdrop) {
@@ -102,10 +110,12 @@ test("menu actions call the expected callbacks", () => {
 
     fireEvent.click(backdrop);
     fireEvent.click(getByRole("button", { name: /close menu/i }));
+    fireEvent.click(getByRole("checkbox", { name: /show level best stats/i }));
     fireEvent.click(getByRole("button", { name: /sfx settings/i }));
     fireEvent.click(getByRole("button", { name: /^about$/i }));
 
     expect(onClose).toHaveBeenCalledTimes(2);
+    expect(onShowLevelBestChange).toHaveBeenCalledWith(true);
     expect(onOpenSfx).toHaveBeenCalledTimes(1);
     expect(onOpenAbout).toHaveBeenCalledTimes(1);
 });

--- a/src/components/hamburger-menu.tsx
+++ b/src/components/hamburger-menu.tsx
@@ -4,12 +4,21 @@ import { ThemeSwitcher } from "./theme-switcher";
 
 type HamburgerMenuProps = {
     open: boolean;
+    showLevelBest: boolean;
+    onShowLevelBestChange: (next: boolean) => void;
     onClose: () => void;
     onOpenSfx: () => void;
     onOpenAbout: () => void;
 };
 
-function HamburgerMenuImpl({ open, onClose, onOpenSfx, onOpenAbout }: HamburgerMenuProps) {
+function HamburgerMenuImpl({
+    open,
+    showLevelBest,
+    onShowLevelBestChange,
+    onClose,
+    onOpenSfx,
+    onOpenAbout,
+}: HamburgerMenuProps) {
     return (
         <>
             <div
@@ -42,6 +51,25 @@ function HamburgerMenuImpl({ open, onClose, onOpenSfx, onOpenAbout }: HamburgerM
                     <div className={style.menuThemeRow}>
                         <span className={style.menuThemeLabel}>Theme</span>
                         <ThemeSwitcher />
+                    </div>
+
+                    <div className={style.menuThemeRow}>
+                        <span className={style.menuThemeLabel}>Show Level Best</span>
+                        <div className={style.themeSliderRow}>
+                            <input
+                                id="level-best-toggle"
+                                className={style.themeToggleCheckbox}
+                                type="checkbox"
+                                checked={showLevelBest}
+                                onChange={(event) => onShowLevelBestChange(event.target.checked)}
+                                aria-label={showLevelBest ? "Hide level best stats" : "Show level best stats"}
+                            />
+                            <label htmlFor="level-best-toggle" className={style.themeToggleLabel}>
+                                <span className={style.levelBestToggleOff} aria-hidden="true">Off</span>
+                                <span className={style.levelBestToggleOn} aria-hidden="true">On</span>
+                                <span className={style.themeToggleBall} />
+                            </label>
+                        </div>
                     </div>
 
                     <button type="button" className={style.menuItemButton} onClick={onOpenSfx}>

--- a/src/components/hamburger-menu.tsx
+++ b/src/components/hamburger-menu.tsx
@@ -4,8 +4,8 @@ import { ThemeSwitcher } from "./theme-switcher";
 
 type HamburgerMenuProps = {
     open: boolean;
-    showLevelBest: boolean;
-    onShowLevelBestChange: (next: boolean) => void;
+    showPlayStats: boolean;
+    onShowPlayStatsChange: (next: boolean) => void;
     onClose: () => void;
     onOpenSfx: () => void;
     onOpenAbout: () => void;
@@ -13,8 +13,8 @@ type HamburgerMenuProps = {
 
 function HamburgerMenuImpl({
     open,
-    showLevelBest,
-    onShowLevelBestChange,
+    showPlayStats,
+    onShowPlayStatsChange,
     onClose,
     onOpenSfx,
     onOpenAbout,
@@ -54,17 +54,17 @@ function HamburgerMenuImpl({
                     </div>
 
                     <div className={style.menuThemeRow}>
-                        <span className={style.menuThemeLabel}>Show Level Best</span>
+                        <span className={style.menuThemeLabel}>Show Play Stats</span>
                         <div className={style.themeSliderRow}>
                             <input
-                                id="level-best-toggle"
+                                id="play-stats-toggle"
                                 className={style.themeToggleCheckbox}
                                 type="checkbox"
-                                checked={showLevelBest}
-                                onChange={(event) => onShowLevelBestChange(event.target.checked)}
-                                aria-label={showLevelBest ? "Hide level best stats" : "Show level best stats"}
+                                checked={showPlayStats}
+                                onChange={(event) => onShowPlayStatsChange(event.target.checked)}
+                                aria-label={showPlayStats ? "Hide play stats" : "Show play stats"}
                             />
-                            <label htmlFor="level-best-toggle" className={style.themeToggleLabel}>
+                            <label htmlFor="play-stats-toggle" className={style.themeToggleLabel}>
                                 <span className={style.levelBestToggleOff} aria-hidden="true">Off</span>
                                 <span className={style.levelBestToggleOn} aria-hidden="true">On</span>
                                 <span className={style.themeToggleBall} />

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -941,7 +941,7 @@
     height: 24px;
     border-radius: 50%;
     background: var(--surface);
-    box-shadow: 0 1px 2px rgba(0, 0, 0, 0.22);
+    border: 1px solid color-mix(in srgb, var(--foreground) 16%, transparent);
     transition: transform 0.2s ease;
 }
 

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -53,6 +53,31 @@
     justify-self: end;
 }
 
+.bestStatsBar {
+    width: 100%;
+    display: grid;
+    grid-template-columns: 1fr;
+    gap: 8px;
+    flex-shrink: 0;
+}
+
+.bestStatsChip {
+    margin: 0;
+    border: 1px solid var(--border);
+    border-radius: 999px;
+    background: color-mix(in srgb, var(--surface) 90%, var(--text) 10%);
+    color: var(--muted);
+    padding: 7px 12px;
+    font-size: 0.78rem;
+    font-weight: 700;
+    line-height: 1.2;
+    text-align: center;
+    font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
 .menuToggleButton {
     width: 56px;
     height: 56px;
@@ -188,6 +213,7 @@
     .topBarSpacer {
         display: none;
     }
+
 }
 
 .level {
@@ -311,6 +337,25 @@
 .completionText {
     margin: 10px 0 18px;
     color: var(--muted);
+}
+
+.completionStats {
+    display: grid;
+    gap: 8px;
+    margin: 4px 0 18px;
+}
+
+.completionStatsLine {
+    margin: 0;
+    border: 1px solid var(--border);
+    border-radius: 10px;
+    background: color-mix(in srgb, var(--surface) 90%, var(--text) 10%);
+    color: var(--muted);
+    padding: 8px 10px;
+    font-size: 0.84rem;
+    font-weight: 700;
+    line-height: 1.3;
+    font-variant-numeric: tabular-nums;
 }
 
 .completionButton {

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -54,23 +54,31 @@
 }
 
 .bestStatsBar {
-    width: 100%;
-    display: grid;
-    grid-template-columns: 1fr;
-    gap: 8px;
+    width: max-content;
+    max-width: 100%;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    align-self: flex-start;
+    margin: 0;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--surface) 90%, var(--text) 10%);
+    color: var(--muted);
+    padding: 6px 10px;
+    text-align: center;
     flex-shrink: 0;
 }
 
 .bestStatsChip {
     margin: 0;
-    border: 1px solid var(--border);
-    border-radius: 999px;
-    background: color-mix(in srgb, var(--surface) 90%, var(--text) 10%);
-    color: var(--muted);
-    padding: 7px 12px;
-    font-size: 0.78rem;
+    border: 0;
+    background: none;
+    color: inherit;
+    padding: 0;
+    font-size: 0.75rem;
     font-weight: 700;
-    line-height: 1.2;
+    line-height: 1.1;
     text-align: center;
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
@@ -340,22 +348,34 @@
 }
 
 .completionStats {
-    display: grid;
-    gap: 8px;
-    margin: 4px 0 18px;
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+    width: max-content;
+    max-width: 100%;
+    margin: 4px auto 18px;
+    border: 1px solid var(--border);
+    border-radius: 12px;
+    background: color-mix(in srgb, var(--surface) 90%, var(--text) 10%);
+    color: var(--muted);
+    padding: 6px 10px;
+    text-align: center;
 }
 
 .completionStatsLine {
     margin: 0;
-    border: 1px solid var(--border);
-    border-radius: 10px;
-    background: color-mix(in srgb, var(--surface) 90%, var(--text) 10%);
-    color: var(--muted);
-    padding: 8px 10px;
-    font-size: 0.84rem;
+    border: 0;
+    background: none;
+    color: inherit;
+    padding: 0;
+    font-size: 0.8rem;
     font-weight: 700;
-    line-height: 1.3;
+    line-height: 1.2;
+    text-align: center;
     font-variant-numeric: tabular-nums;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .completionButton {

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -953,6 +953,17 @@
     color: var(--text);
 }
 
+.levelBestToggleOff,
+.levelBestToggleOn {
+    width: 14px;
+    text-align: center;
+    font-size: 0.56rem;
+    font-weight: 800;
+    letter-spacing: 0.04em;
+    text-transform: uppercase;
+    color: var(--text);
+}
+
 .themeToggleCheckbox:checked+.themeToggleLabel {
     background: var(--accent);
     border-color: var(--accent);

--- a/src/hooks/sokoban.test.ts
+++ b/src/hooks/sokoban.test.ts
@@ -65,6 +65,7 @@ test("blocked movement updates player orientation without moving or adding progr
     expect(result.current.level.playerDirection).toBe(Direction.Right);
     expect(result.current.level.playerPosition).toEqual({ row: 1, column: 1 });
     expect(result.current.hasProgress).toBe(false);
+    expect(result.current.moveCount).toBe(0);
 
     let outcome: MoveOutcome = "step";
     act(() => {
@@ -76,6 +77,64 @@ test("blocked movement updates player orientation without moving or adding progr
     expect(result.current.level.playerPosition).toEqual({ row: 1, column: 1 });
     expect(result.current.level.shape[1][1]).toBe(Block.player);
     expect(result.current.hasProgress).toBe(false);
+    expect(result.current.moveCount).toBe(0);
+});
+
+test("tracks realtime play status for moves and elapsed time", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+
+    const level = createLevel([
+        [Block.wall, Block.wall, Block.wall, Block.wall, Block.wall],
+        [Block.wall, Block.player, Block.box, Block.empty, Block.wall],
+        [Block.wall, Block.objective, Block.wall, Block.wall, Block.wall],
+        [Block.wall, Block.wall, Block.wall, Block.wall, Block.wall],
+    ]);
+
+    mockedUseLevels.mockReturnValue({
+        index: 0,
+        level,
+        levelPacks: [
+            {
+                packId: "test-pack",
+                title: "Test Pack",
+                description: "",
+                email: "",
+                levels: [level],
+            },
+        ],
+        loadNext: vi.fn(),
+        loadPrevious: vi.fn(),
+        loadLevel: vi.fn(),
+        totalLevels: 1,
+    });
+
+    const { result } = renderHook(() => useSokoban());
+
+    expect(result.current.moveCount).toBe(0);
+    expect(result.current.elapsedTimeMs).toBe(0);
+
+    act(() => {
+        vi.advanceTimersByTime(1250);
+    });
+
+    expect(result.current.elapsedTimeMs).toBeGreaterThanOrEqual(1000);
+
+    let outcome: MoveOutcome = "blocked";
+    act(() => {
+        outcome = result.current.move(Direction.Right);
+    });
+
+    expect(outcome).toBe("crate-push");
+    expect(result.current.moveCount).toBe(1);
+
+    let didUndo = false;
+    act(() => {
+        didUndo = result.current.undo();
+    });
+
+    expect(didUndo).toBe(true);
+    expect(result.current.moveCount).toBe(0);
 });
 
 test("captures completion metrics when level is solved", () => {
@@ -117,6 +176,7 @@ test("captures completion metrics when level is solved", () => {
 
     expect(outcome).toBe("step");
     expect(result.current.state).toBe(State.completed);
+    expect(result.current.elapsedTimeMs).toBe(3600);
     expect(result.current.completionMetrics).toEqual({
         moves: 1,
         timeMs: 3600,
@@ -172,5 +232,6 @@ test("resets completion metrics after advancing from completed state", () => {
 
     expect(loadNext).toHaveBeenCalledTimes(1);
     expect(result.current.state).toBe(State.playing);
+    expect(result.current.elapsedTimeMs).toBe(0);
     expect(result.current.completionMetrics).toBeNull();
 });

--- a/src/hooks/sokoban.test.ts
+++ b/src/hooks/sokoban.test.ts
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 import { act, renderHook } from "@testing-library/react";
-import { beforeEach, expect, test, vi } from "vitest";
-import { useSokoban, Direction, type MoveOutcome } from "./sokoban";
+import { afterEach, beforeEach, expect, test, vi } from "vitest";
+import { useSokoban, Direction, State, type MoveOutcome } from "./sokoban";
 import { Block, useLevels, type Level } from "./levels";
 
 vi.mock("./levels", async () => {
@@ -29,6 +29,10 @@ function createLevel(shape: Block[][]): Level {
 beforeEach(() => {
     mockedUseLevels.mockReset();
     localStorage.clear();
+});
+
+afterEach(() => {
+    vi.useRealTimers();
 });
 
 test("blocked movement updates player orientation without moving or adding progress", () => {
@@ -72,4 +76,101 @@ test("blocked movement updates player orientation without moving or adding progr
     expect(result.current.level.playerPosition).toEqual({ row: 1, column: 1 });
     expect(result.current.level.shape[1][1]).toBe(Block.player);
     expect(result.current.hasProgress).toBe(false);
+});
+
+test("captures completion metrics when level is solved", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1_000);
+
+    const level = createLevel([
+        [Block.wall, Block.wall, Block.wall, Block.wall],
+        [Block.wall, Block.player, Block.empty, Block.wall],
+        [Block.wall, Block.wall, Block.wall, Block.wall],
+    ]);
+
+    mockedUseLevels.mockReturnValue({
+        index: 0,
+        level,
+        levelPacks: [
+            {
+                packId: "test-pack",
+                title: "Test Pack",
+                description: "",
+                email: "",
+                levels: [level],
+            },
+        ],
+        loadNext: vi.fn(),
+        loadPrevious: vi.fn(),
+        loadLevel: vi.fn(),
+        totalLevels: 1,
+    });
+
+    const { result } = renderHook(() => useSokoban());
+
+    vi.setSystemTime(4_600);
+
+    let outcome: MoveOutcome = "blocked";
+    act(() => {
+        outcome = result.current.move(Direction.Right);
+    });
+
+    expect(outcome).toBe("step");
+    expect(result.current.state).toBe(State.completed);
+    expect(result.current.completionMetrics).toEqual({
+        moves: 1,
+        timeMs: 3600,
+    });
+});
+
+test("resets completion metrics after advancing from completed state", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(2_000);
+
+    const loadNext = vi.fn();
+    const level = createLevel([
+        [Block.wall, Block.wall, Block.wall, Block.wall],
+        [Block.wall, Block.player, Block.empty, Block.wall],
+        [Block.wall, Block.wall, Block.wall, Block.wall],
+    ]);
+
+    mockedUseLevels.mockReturnValue({
+        index: 0,
+        level,
+        levelPacks: [
+            {
+                packId: "test-pack",
+                title: "Test Pack",
+                description: "",
+                email: "",
+                levels: [level],
+            },
+        ],
+        loadNext,
+        loadPrevious: vi.fn(),
+        loadLevel: vi.fn(),
+        totalLevels: 1,
+    });
+
+    const { result } = renderHook(() => useSokoban());
+
+    vi.setSystemTime(3_500);
+
+    act(() => {
+        result.current.move(Direction.Right);
+    });
+
+    expect(result.current.state).toBe(State.completed);
+    expect(result.current.completionMetrics).toEqual({
+        moves: 1,
+        timeMs: 1500,
+    });
+
+    act(() => {
+        result.current.next();
+    });
+
+    expect(loadNext).toHaveBeenCalledTimes(1);
+    expect(result.current.state).toBe(State.playing);
+    expect(result.current.completionMetrics).toBeNull();
 });

--- a/src/hooks/sokoban.ts
+++ b/src/hooks/sokoban.ts
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from "react";
+import { useEffect, useState, useCallback, useRef } from "react";
 import { Level, Block, useLevels } from "./levels";
 import { cloneDeep } from "lodash";
 
@@ -15,6 +15,11 @@ export enum State {
 }
 
 export type MoveOutcome = "blocked" | "step" | "crate-push" | "crate-docked";
+
+export type CompletionMetrics = {
+  moves: number;
+  timeMs: number;
+};
 
 type Position = {
   row: number;
@@ -58,6 +63,9 @@ export function useSokoban() {
   const { index, level, levelPacks, loadNext, loadPrevious, loadLevel: loadLevelById, totalLevels } = useLevels();
   const [state, setState] = useState<State>(State.playing);
   const [hasProgress, setHasProgress] = useState(false);
+  const [moveCount, setMoveCount] = useState(0);
+  const [completionMetrics, setCompletionMetrics] = useState<CompletionMetrics | null>(null);
+  const levelStartedAtRef = useRef(Date.now());
   const initboard = useCallback(
     () => [
       {
@@ -69,6 +77,13 @@ export function useSokoban() {
     [level]
   );
   const [board, setBoard] = useState<Board>(initboard);
+
+  const resetLevelRuntime = useCallback(() => {
+    setMoveCount(0);
+    setCompletionMetrics(null);
+    levelStartedAtRef.current = Date.now();
+  }, []);
+
   const move = useCallback(
     (direction: Direction): MoveOutcome => {
       if (state !== State.playing) {
@@ -115,6 +130,7 @@ export function useSokoban() {
           next.shape[next.playerPosition.row][next.playerPosition.column]
         )
       ) {
+        const nextMoveCount = moveCount + 1;
         next.shape[last.playerPosition.row][last.playerPosition.column] -=
           Block.player;
         next.shape[next.playerPosition.row][next.playerPosition.column] +=
@@ -125,11 +141,17 @@ export function useSokoban() {
               [Block.objective, Block.playerOnObjective].includes(block)
             )
           )
-        )
+        ) {
           setState(State.completed);
+          setCompletionMetrics({
+            moves: nextMoveCount,
+            timeMs: Math.max(0, Date.now() - levelStartedAtRef.current),
+          });
+        }
         if (!movingBlock) board.pop();
 
         setHasProgress(true);
+        setMoveCount(nextMoveCount);
         setBoard([...board, next]);
 
         if (movingBlock) {
@@ -145,7 +167,7 @@ export function useSokoban() {
 
       return "blocked";
     },
-    [board, state]
+    [board, moveCount, state]
   );
 
   const next = useCallback(() => {
@@ -153,33 +175,38 @@ export function useSokoban() {
       loadNext();
       setState(State.playing);
       setHasProgress(false);
+      resetLevelRuntime();
     }
-  }, [state, loadNext]);
+  }, [state, loadNext, resetLevelRuntime]);
 
   const nextLevel = useCallback(() => {
     loadNext();
     setState(State.playing);
     setHasProgress(false);
-  }, [loadNext]);
+    resetLevelRuntime();
+  }, [loadNext, resetLevelRuntime]);
 
   const previousLevel = useCallback(() => {
     loadPrevious();
     setState(State.playing);
     setHasProgress(false);
-  }, [loadPrevious]);
+    resetLevelRuntime();
+  }, [loadPrevious, resetLevelRuntime]);
 
   const loadLevel = useCallback(
     (levelId: string) => {
       loadLevelById(levelId);
       setState(State.playing);
       setHasProgress(false);
+      resetLevelRuntime();
     },
-    [loadLevelById]
+    [loadLevelById, resetLevelRuntime]
   );
 
   const undo = useCallback(() => {
     if (state === State.playing && board.length > 1) {
       setBoard(board.slice(0, -1));
+      setMoveCount((current) => Math.max(0, current - 1));
       return true;
     }
 
@@ -189,21 +216,24 @@ export function useSokoban() {
     if (state === State.playing) {
       setBoard(initboard());
       setHasProgress(false);
+      resetLevelRuntime();
     }
-  }, [state, initboard]);
+  }, [state, initboard, resetLevelRuntime]);
 
   useEffect(() => {
     if (board[0].levelId !== level.levelId) {
       setBoard(initboard());
       setHasProgress(false);
+      resetLevelRuntime();
     }
-  }, [board, state, level, loadNext, next, restart, initboard, move]);
+  }, [board, state, level, loadNext, next, restart, initboard, move, resetLevelRuntime]);
 
   return {
     index,
     level: board[board.length - 1],
     levelPacks,
     totalLevels,
+    completionMetrics,
     state,
     move,
     next,

--- a/src/hooks/sokoban.ts
+++ b/src/hooks/sokoban.ts
@@ -64,6 +64,7 @@ export function useSokoban() {
   const [state, setState] = useState<State>(State.playing);
   const [hasProgress, setHasProgress] = useState(false);
   const [moveCount, setMoveCount] = useState(0);
+  const [elapsedTimeMs, setElapsedTimeMs] = useState(0);
   const [completionMetrics, setCompletionMetrics] = useState<CompletionMetrics | null>(null);
   const levelStartedAtRef = useRef(Date.now());
   const initboard = useCallback(
@@ -80,6 +81,7 @@ export function useSokoban() {
 
   const resetLevelRuntime = useCallback(() => {
     setMoveCount(0);
+    setElapsedTimeMs(0);
     setCompletionMetrics(null);
     levelStartedAtRef.current = Date.now();
   }, []);
@@ -142,10 +144,12 @@ export function useSokoban() {
             )
           )
         ) {
+          const finalElapsedTimeMs = Math.max(0, Date.now() - levelStartedAtRef.current);
           setState(State.completed);
+          setElapsedTimeMs(finalElapsedTimeMs);
           setCompletionMetrics({
             moves: nextMoveCount,
-            timeMs: Math.max(0, Date.now() - levelStartedAtRef.current),
+            timeMs: finalElapsedTimeMs,
           });
         }
         if (!movingBlock) board.pop();
@@ -228,11 +232,28 @@ export function useSokoban() {
     }
   }, [board, state, level, loadNext, next, restart, initboard, move, resetLevelRuntime]);
 
+  useEffect(() => {
+    if (state !== State.playing || typeof window === "undefined") {
+      return;
+    }
+
+    const updateElapsedTime = () => {
+      setElapsedTimeMs(Math.max(0, Date.now() - levelStartedAtRef.current));
+    };
+
+    updateElapsedTime();
+
+    const timerId = window.setInterval(updateElapsedTime, 250);
+    return () => window.clearInterval(timerId);
+  }, [state]);
+
   return {
     index,
     level: board[board.length - 1],
     levelPacks,
     totalLevels,
+    moveCount,
+    elapsedTimeMs,
     completionMetrics,
     state,
     move,

--- a/src/hooks/useStats.test.ts
+++ b/src/hooks/useStats.test.ts
@@ -1,0 +1,202 @@
+import "@testing-library/jest-dom/vitest";
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, expect, test } from "vitest";
+import {
+    SOKOBAN_STATS_STORAGE_KEY,
+    useStats,
+    type SokobanStats,
+} from "./useStats";
+
+function readStoredStats(): SokobanStats {
+    const raw = window.localStorage.getItem(SOKOBAN_STATS_STORAGE_KEY);
+    if (!raw) {
+        throw new Error("Expected stats payload in storage");
+    }
+
+    return JSON.parse(raw) as SokobanStats;
+}
+
+beforeEach(() => {
+    window.localStorage.clear();
+});
+
+test("starts with empty stats when nothing is stored", () => {
+    const { result } = renderHook(() => useStats());
+
+    expect(result.current.stats.progression).toEqual({});
+    expect(result.current.stats.records).toEqual({});
+    expect(result.current.stats.version).toBe(1);
+});
+
+test("loads and sanitizes partially invalid stored payload", () => {
+    window.localStorage.setItem(
+        SOKOBAN_STATS_STORAGE_KEY,
+        JSON.stringify({
+            version: 999,
+            updatedAt: 321,
+            progression: {
+                "Atlas01:0": {
+                    playCount: "bad",
+                    completionCount: 2,
+                    isCompleted: true,
+                    bestMovesInLevel: 120,
+                    bestTimeMsInLevel: 9000,
+                    lastPlayedAt: 100,
+                    lastCompletedAt: 200,
+                },
+            },
+            records: {
+                abc12345: {
+                    bestMoves: "bad",
+                    bestTimeMs: 1000,
+                    solveCount: 3,
+                    firstSolvedAt: 10,
+                    lastSolvedAt: 20,
+                },
+            },
+        })
+    );
+
+    const { result } = renderHook(() => useStats());
+
+    expect(result.current.stats.version).toBe(1);
+    expect(result.current.stats.updatedAt).toBe(321);
+    expect(result.current.stats.progression["Atlas01:0"]).toMatchObject({
+        playCount: 0,
+        completionCount: 2,
+        isCompleted: true,
+        bestMovesInLevel: 120,
+        bestTimeMsInLevel: 9000,
+    });
+    expect(result.current.stats.records.abc12345).toBeUndefined();
+});
+
+test("saveLevelResult creates progression and records and persists", () => {
+    const { result } = renderHook(() => useStats());
+
+    act(() => {
+        result.current.saveLevelResult({
+            levelId: "Atlas01:0",
+            puzzleId: "deadbeef",
+            moves: 57,
+            timeMs: 12345,
+            completedAt: 1000,
+        });
+    });
+
+    expect(result.current.stats.progression["Atlas01:0"]).toMatchObject({
+        playCount: 1,
+        completionCount: 1,
+        isCompleted: true,
+        bestMovesInLevel: 57,
+        bestTimeMsInLevel: 12345,
+        lastPlayedAt: 1000,
+        lastCompletedAt: 1000,
+    });
+    expect(result.current.stats.records.deadbeef).toMatchObject({
+        bestMoves: 57,
+        bestTimeMs: 12345,
+        solveCount: 1,
+        firstSolvedAt: 1000,
+        lastSolvedAt: 1000,
+    });
+
+    const stored = readStoredStats();
+    expect(stored.progression["Atlas01:0"].completionCount).toBe(1);
+    expect(stored.records.deadbeef.bestMoves).toBe(57);
+});
+
+test("saveLevelResult keeps best metrics while counting plays", () => {
+    const { result } = renderHook(() => useStats());
+
+    act(() => {
+        result.current.saveLevelResult({
+            levelId: "Atlas01:0",
+            puzzleId: "deadbeef",
+            moves: 35,
+            timeMs: 9000,
+            completedAt: 1000,
+        });
+    });
+
+    act(() => {
+        result.current.saveLevelResult({
+            levelId: "Atlas01:0",
+            puzzleId: "deadbeef",
+            moves: 42,
+            timeMs: 8500,
+            completedAt: 2000,
+        });
+    });
+
+    expect(result.current.stats.progression["Atlas01:0"]).toMatchObject({
+        playCount: 2,
+        completionCount: 2,
+        bestMovesInLevel: 35,
+        bestTimeMsInLevel: 8500,
+        lastCompletedAt: 2000,
+    });
+    expect(result.current.stats.records.deadbeef).toMatchObject({
+        bestMoves: 35,
+        bestTimeMs: 8500,
+        solveCount: 2,
+        firstSolvedAt: 1000,
+        lastSolvedAt: 2000,
+    });
+});
+
+test("shared puzzleId across different levels updates one global record", () => {
+    const { result } = renderHook(() => useStats());
+
+    act(() => {
+        result.current.saveLevelResult({
+            levelId: "Atlas01:0",
+            puzzleId: "cafef00d",
+            moves: 50,
+            timeMs: 11000,
+            completedAt: 1000,
+        });
+    });
+
+    act(() => {
+        result.current.saveLevelResult({
+            levelId: "Atlas02:4",
+            puzzleId: "cafef00d",
+            moves: 45,
+            timeMs: 12000,
+            completedAt: 1500,
+        });
+    });
+
+    expect(result.current.stats.progression["Atlas01:0"].completionCount).toBe(1);
+    expect(result.current.stats.progression["Atlas02:4"].completionCount).toBe(1);
+    expect(result.current.stats.records.cafef00d).toMatchObject({
+        bestMoves: 45,
+        bestTimeMs: 11000,
+        solveCount: 2,
+    });
+});
+
+test("clearStats removes in-memory and localStorage stats", () => {
+    const { result } = renderHook(() => useStats());
+
+    act(() => {
+        result.current.saveLevelResult({
+            levelId: "Atlas01:0",
+            puzzleId: "deadbeef",
+            moves: 57,
+            timeMs: 12345,
+            completedAt: 1000,
+        });
+    });
+
+    expect(window.localStorage.getItem(SOKOBAN_STATS_STORAGE_KEY)).not.toBeNull();
+
+    act(() => {
+        result.current.clearStats();
+    });
+
+    expect(result.current.stats.progression).toEqual({});
+    expect(result.current.stats.records).toEqual({});
+    expect(window.localStorage.getItem(SOKOBAN_STATS_STORAGE_KEY)).toBeNull();
+});

--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -1,0 +1,288 @@
+import { useCallback, useEffect, useState } from "react";
+
+export const SOKOBAN_STATS_STORAGE_KEY = "sokoban.stats.v1";
+export const SOKOBAN_STATS_SCHEMA_VERSION = 1 as const;
+
+export type LevelProgress = {
+    playCount: number;
+    completionCount: number;
+    isCompleted: boolean;
+    lastPlayedAt: number | null;
+    lastCompletedAt: number | null;
+    bestMovesInLevel: number | null;
+    bestTimeMsInLevel: number | null;
+};
+
+export type PuzzleRecord = {
+    bestMoves: number;
+    bestTimeMs: number;
+    solveCount: number;
+    firstSolvedAt: number;
+    lastSolvedAt: number;
+};
+
+export type SokobanStats = {
+    version: typeof SOKOBAN_STATS_SCHEMA_VERSION;
+    updatedAt: number;
+    progression: Record<string, LevelProgress>;
+    records: Record<string, PuzzleRecord>;
+};
+
+export type SaveLevelResultInput = {
+    levelId: string;
+    puzzleId: string;
+    moves: number;
+    timeMs: number;
+    completedAt?: number;
+};
+
+function isObject(value: unknown): value is Record<string, unknown> {
+    return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function toNonNegativeInteger(value: unknown): number {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+        return 0;
+    }
+
+    return Math.max(0, Math.floor(value));
+}
+
+function toBestMetric(value: unknown): number | null {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+        return null;
+    }
+
+    return Math.max(0, Math.floor(value));
+}
+
+function toTimestamp(value: unknown): number | null {
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+        return null;
+    }
+
+    const timestamp = Math.floor(value);
+    return timestamp > 0 ? timestamp : null;
+}
+
+function createEmptyLevelProgress(): LevelProgress {
+    return {
+        playCount: 0,
+        completionCount: 0,
+        isCompleted: false,
+        lastPlayedAt: null,
+        lastCompletedAt: null,
+        bestMovesInLevel: null,
+        bestTimeMsInLevel: null,
+    };
+}
+
+function createEmptyStats(updatedAt = Date.now()): SokobanStats {
+    return {
+        version: SOKOBAN_STATS_SCHEMA_VERSION,
+        updatedAt,
+        progression: {},
+        records: {},
+    };
+}
+
+function sanitizeLevelProgress(value: unknown): LevelProgress {
+    if (!isObject(value)) {
+        return createEmptyLevelProgress();
+    }
+
+    const completionCount = toNonNegativeInteger(value.completionCount);
+    const isCompleted =
+        typeof value.isCompleted === "boolean" ? value.isCompleted : completionCount > 0;
+
+    return {
+        playCount: toNonNegativeInteger(value.playCount),
+        completionCount,
+        isCompleted,
+        lastPlayedAt: toTimestamp(value.lastPlayedAt),
+        lastCompletedAt: toTimestamp(value.lastCompletedAt),
+        bestMovesInLevel: toBestMetric(value.bestMovesInLevel),
+        bestTimeMsInLevel: toBestMetric(value.bestTimeMsInLevel),
+    };
+}
+
+function sanitizePuzzleRecord(value: unknown): PuzzleRecord | null {
+    if (!isObject(value)) {
+        return null;
+    }
+
+    const bestMoves = toBestMetric(value.bestMoves);
+    const bestTimeMs = toBestMetric(value.bestTimeMs);
+    const firstSolvedAt = toTimestamp(value.firstSolvedAt);
+    const lastSolvedAt = toTimestamp(value.lastSolvedAt);
+    const solveCount = Math.max(1, toNonNegativeInteger(value.solveCount));
+
+    if (bestMoves === null || bestTimeMs === null || firstSolvedAt === null || lastSolvedAt === null) {
+        return null;
+    }
+
+    return {
+        bestMoves,
+        bestTimeMs,
+        solveCount,
+        firstSolvedAt,
+        lastSolvedAt: Math.max(lastSolvedAt, firstSolvedAt),
+    };
+}
+
+function readStoredStats(): SokobanStats {
+    if (typeof window === "undefined") {
+        return createEmptyStats();
+    }
+
+    try {
+        const raw = window.localStorage.getItem(SOKOBAN_STATS_STORAGE_KEY);
+        if (!raw) {
+            return createEmptyStats();
+        }
+
+        const parsed = JSON.parse(raw) as unknown;
+        if (!isObject(parsed)) {
+            return createEmptyStats();
+        }
+
+        const progression: Record<string, LevelProgress> = {};
+        if (isObject(parsed.progression)) {
+            for (const [levelId, value] of Object.entries(parsed.progression)) {
+                progression[levelId] = sanitizeLevelProgress(value);
+            }
+        }
+
+        const records: Record<string, PuzzleRecord> = {};
+        if (isObject(parsed.records)) {
+            for (const [puzzleId, value] of Object.entries(parsed.records)) {
+                const sanitized = sanitizePuzzleRecord(value);
+                if (sanitized) {
+                    records[puzzleId] = sanitized;
+                }
+            }
+        }
+
+        const updatedAt = toTimestamp(parsed.updatedAt) ?? Date.now();
+
+        return {
+            version: SOKOBAN_STATS_SCHEMA_VERSION,
+            updatedAt,
+            progression,
+            records,
+        };
+    } catch {
+        return createEmptyStats();
+    }
+}
+
+function writeStoredStats(stats: SokobanStats) {
+    if (typeof window === "undefined") {
+        return;
+    }
+
+    window.localStorage.setItem(SOKOBAN_STATS_STORAGE_KEY, JSON.stringify(stats));
+}
+
+function nextBest(current: number | null, candidate: number): number {
+    if (current === null) {
+        return candidate;
+    }
+
+    return Math.min(current, candidate);
+}
+
+export function useStats() {
+    const [stats, setStats] = useState<SokobanStats>(readStoredStats);
+
+    useEffect(() => {
+        if (typeof window === "undefined") {
+            return;
+        }
+
+        const onStorage = (event: StorageEvent) => {
+            if (event.key !== SOKOBAN_STATS_STORAGE_KEY) {
+                return;
+            }
+
+            setStats(readStoredStats());
+        };
+
+        window.addEventListener("storage", onStorage);
+        return () => window.removeEventListener("storage", onStorage);
+    }, []);
+
+    const saveLevelResult = useCallback((input: SaveLevelResultInput) => {
+        if (!input.levelId || !input.puzzleId) {
+            return;
+        }
+
+        const completedAt = toTimestamp(input.completedAt) ?? Date.now();
+        const moves = toNonNegativeInteger(input.moves);
+        const timeMs = toNonNegativeInteger(input.timeMs);
+
+        setStats((current) => {
+            const currentProgress = current.progression[input.levelId] ?? createEmptyLevelProgress();
+            const nextProgress: LevelProgress = {
+                playCount: currentProgress.playCount + 1,
+                completionCount: currentProgress.completionCount + 1,
+                isCompleted: true,
+                lastPlayedAt: completedAt,
+                lastCompletedAt: completedAt,
+                bestMovesInLevel: nextBest(currentProgress.bestMovesInLevel, moves),
+                bestTimeMsInLevel: nextBest(currentProgress.bestTimeMsInLevel, timeMs),
+            };
+
+            const currentRecord = current.records[input.puzzleId];
+            const nextRecord: PuzzleRecord = currentRecord
+                ? {
+                    bestMoves: Math.min(currentRecord.bestMoves, moves),
+                    bestTimeMs: Math.min(currentRecord.bestTimeMs, timeMs),
+                    solveCount: currentRecord.solveCount + 1,
+                    firstSolvedAt: currentRecord.firstSolvedAt,
+                    lastSolvedAt: completedAt,
+                }
+                : {
+                    bestMoves: moves,
+                    bestTimeMs: timeMs,
+                    solveCount: 1,
+                    firstSolvedAt: completedAt,
+                    lastSolvedAt: completedAt,
+                };
+
+            const nextStats: SokobanStats = {
+                version: SOKOBAN_STATS_SCHEMA_VERSION,
+                updatedAt: completedAt,
+                progression: {
+                    ...current.progression,
+                    [input.levelId]: nextProgress,
+                },
+                records: {
+                    ...current.records,
+                    [input.puzzleId]: nextRecord,
+                },
+            };
+
+            writeStoredStats(nextStats);
+            return nextStats;
+        });
+    }, []);
+
+    const clearStats = useCallback(() => {
+        setStats((current) => {
+            const next = createEmptyStats(current.updatedAt);
+            if (typeof window !== "undefined") {
+                window.localStorage.removeItem(SOKOBAN_STATS_STORAGE_KEY);
+            }
+            return next;
+        });
+    }, []);
+
+    return {
+        stats,
+        saveLevelResult,
+        clearStats,
+    };
+}
+
+export type { SaveLevelResultInput as SaveLevelResultParams };


### PR DESCRIPTION
### Description
This Pull Request introduces persistent local storage for gameplay statistics. It leverages the "Dual-ID" architecture established previously to track both linear pack progression and global high scores for specific puzzle layouts across sessions.

### Key Changes
* **Local Storage Schema:** Introduced a unified `SokobanStats` object in local storage, separating data into two distinct categories:
  * `progression`: Keyed by `levelId` to track if a specific level within a pack is completed and its total play count.
  * `records`: Keyed by `puzzleId` (the FNV-1a fingerprint) to track the all-time best moves and best time for a specific puzzle layout, enabling cross-pack high score synchronization.
* **Isolated Stats Hook (`useStats.ts`):** Created a dedicated hook to manage local storage interactions. This exposes a `saveLevelResult` function that automatically compares new scores against historical data and updates the records accordingly. This keeps storage logic decoupled from the core game engine, preventing unnecessary component re-renders.
* **Gameplay Metrics Tracking:** Formalized in-game tracking for player performance. The application now actively tracks the "Move Count" (successful pushes and steps) and the "Elapsed Time" for the active level.
* **Game Loop Integration:** Wired the newly created stats hook into the core game loop. Upon reaching the winning board state, the game automatically captures the final time and move count, dispatching the save action right before the completion overlay is rendered.