### PR TITLE
feat: update level persistence to use new storage key

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -108,7 +108,7 @@ UI controls:
 ### Persistence and Behavior
 
 - Board tile size adapts to viewport dimensions and level size.
-- Level index is persisted in `localStorage` (`SokobanLevel`).
+- Current level is persisted by `levelId` in `localStorage` (`sokoban.level-id.v1`).
 - Theme mode is persisted in `localStorage` (`sokoban-theme-mode`).
 - When mode is `auto`, theme follows `prefers-color-scheme` unless `VITE_DEFAULT_THEME` is set to `dark` or `light`.
 - App dialogs use a shared modal component for consistent behavior and close controls.

--- a/src/hooks/levels.test.ts
+++ b/src/hooks/levels.test.ts
@@ -1,7 +1,7 @@
 import "@testing-library/jest-dom/vitest";
 import { act, renderHook } from "@testing-library/react";
 import { beforeEach, expect, test } from "vitest";
-import { useLevels } from "./levels";
+import { SOKOBAN_LEVEL_STORAGE_KEY, useLevels } from "./levels";
 
 beforeEach(() => {
     localStorage.clear();
@@ -57,4 +57,65 @@ test("selecting another pack changes next/previous scope to that pack", () => {
 
     expect(result.current.level.levelId).toBe(secondPackLastLevelId);
     expect(result.current.level.packId).toBe(secondPack.packId);
+});
+
+test("restores level from persisted levelId", () => {
+    const initial = renderHook(() => useLevels());
+    const nonEmptyPack = initial.result.current.levelPacks.find((pack) => pack.levels.length > 0);
+    if (!nonEmptyPack) {
+        throw new Error("Expected at least one non-empty level pack");
+    }
+
+    const targetLevel = nonEmptyPack.levels[Math.min(1, nonEmptyPack.levels.length - 1)];
+    initial.unmount();
+
+    localStorage.setItem(SOKOBAN_LEVEL_STORAGE_KEY, targetLevel.levelId);
+
+    const { result } = renderHook(() => useLevels());
+    expect(result.current.level.levelId).toBe(targetLevel.levelId);
+});
+
+test("ignores legacy SokobanLevel key when new levelId key is absent", () => {
+    const baseline = renderHook(() => useLevels());
+    const expectedInitialLevelId = baseline.result.current.level.levelId;
+    baseline.unmount();
+
+    localStorage.clear();
+    localStorage.setItem("SokobanLevel", "9999");
+
+    const { result } = renderHook(() => useLevels());
+    expect(result.current.level.levelId).toBe(expectedInitialLevelId);
+});
+
+test("persists levelId when navigating next and previous", () => {
+    const { result } = renderHook(() => useLevels());
+
+    act(() => {
+        result.current.loadNext();
+    });
+
+    expect(localStorage.getItem(SOKOBAN_LEVEL_STORAGE_KEY)).toBe(result.current.level.levelId);
+
+    act(() => {
+        result.current.loadPrevious();
+    });
+
+    expect(localStorage.getItem(SOKOBAN_LEVEL_STORAGE_KEY)).toBe(result.current.level.levelId);
+});
+
+test("persists selected levelId when loading a specific level", () => {
+    const { result } = renderHook(() => useLevels());
+    const nonEmptyPack = result.current.levelPacks.find((pack) => pack.levels.length > 0);
+    if (!nonEmptyPack) {
+        throw new Error("Expected at least one non-empty level pack");
+    }
+
+    const targetLevel = nonEmptyPack.levels[Math.min(1, nonEmptyPack.levels.length - 1)];
+
+    act(() => {
+        result.current.loadLevel(targetLevel.levelId);
+    });
+
+    expect(localStorage.getItem(SOKOBAN_LEVEL_STORAGE_KEY)).toBe(targetLevel.levelId);
+    expect(result.current.level.levelId).toBe(targetLevel.levelId);
 });

--- a/src/hooks/levels.ts
+++ b/src/hooks/levels.ts
@@ -176,7 +176,7 @@ function markExteriorVoid(grid: Block[][]): Block[][] {
   return grid;
 }
 
-const SOKOBAN_LEVEL_KEY = "SokobanLevel";
+export const SOKOBAN_LEVEL_STORAGE_KEY = "sokoban.level-id.v1";
 
 function normalizeIndex(index: number, length: number) {
   if (length === 0) return 0;
@@ -245,8 +245,9 @@ function loadLevelData(): LoadedLevelData {
 export function useLevels() {
   const [{ levels, levelPacks, levelIndexById, levelPackRangeById }] = useState<LoadedLevelData>(loadLevelData);
   const [index, setIndex] = useState(() => {
-    const stored = Number(localStorage.getItem(SOKOBAN_LEVEL_KEY));
-    const initial = Number.isFinite(stored) ? stored : 0;
+    const storedLevelId = localStorage.getItem(SOKOBAN_LEVEL_STORAGE_KEY);
+    const storedIndex = storedLevelId ? levelIndexById.get(storedLevelId) : undefined;
+    const initial = storedIndex ?? 0;
     return normalizeIndex(initial, levels.length);
   });
   const level = useMemo(() => levels[index], [levels, index]);
@@ -279,11 +280,14 @@ export function useLevels() {
     (delta: number) => {
       setIndex((current) => {
         const nextIndex = moveIndexWithinActivePack(current, delta);
-        localStorage.setItem(SOKOBAN_LEVEL_KEY, String(nextIndex));
+        const nextLevel = levels[nextIndex];
+        if (nextLevel) {
+          localStorage.setItem(SOKOBAN_LEVEL_STORAGE_KEY, nextLevel.levelId);
+        }
         return nextIndex;
       });
     },
-    [moveIndexWithinActivePack]
+    [levels, moveIndexWithinActivePack]
   );
 
   const loadNext = useCallback(() => {
@@ -302,7 +306,7 @@ export function useLevels() {
           return current;
         }
 
-        localStorage.setItem(SOKOBAN_LEVEL_KEY, String(nextIndex));
+        localStorage.setItem(SOKOBAN_LEVEL_STORAGE_KEY, levelId);
         return nextIndex;
       });
     },


### PR DESCRIPTION
### Description
This Pull Request updates the local storage mechanism responsible for remembering the player's currently active level. As part of the transition to the new pack-aware architecture, the application now persists the specific `levelId` string rather than a legacy flat index, ensuring players resume exactly where they left off within their selected pack.

### Key Changes
* **Storage Key Migration:** Replaced the legacy local storage key with `sokoban.level-id.v1` to persist the active `levelId` (e.g., `Tutorial:0`) between sessions.
* **Test Coverage:** Updated the relevant unit tests to verify the accurate persistence and restoration of the new `levelId` format upon initialization.