### PR TITLE
feat: implement persistent play statistics UI and toggle

### DIFF
--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -4,7 +4,7 @@ import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 import { fireEvent, render, screen, cleanup, act, within } from "@testing-library/react";
 import { vi, expect, test, beforeAll, beforeEach, afterEach } from "vitest";
-import Game from "./Game";
+import Game, { PLAY_STATS_STORAGE_KEY } from "./Game";
 import { Block } from "./hooks/levels";
 import { Direction, State, useSokoban, type MoveOutcome } from "./hooks/sokoban";
 import { useKeyBoard } from "./hooks/keyboard";
@@ -239,6 +239,7 @@ beforeAll(() => {
 });
 
 beforeEach(() => {
+  localStorage.clear();
   mockedUseSokoban.mockReset();
   mockedUseKeyBoard.mockReset();
   mockedUseGameSounds.mockReset();
@@ -571,6 +572,40 @@ test("hides play stats UI when toggle is off by default", () => {
   render(<Game />);
 
   expect(screen.queryByRole("region", { name: /play statistics/i })).not.toBeInTheDocument();
+});
+
+test("restores play stats UI from persisted toggle state", () => {
+  localStorage.setItem(PLAY_STATS_STORAGE_KEY, "true");
+  mockSokoban({ state: State.playing });
+
+  render(<Game />);
+
+  expect(screen.getByRole("region", { name: /play statistics/i })).toBeInTheDocument();
+  expect(screen.getByText(/^Current$/)).toBeInTheDocument();
+  expect(screen.getByText(/^Best$/)).toBeInTheDocument();
+});
+
+test("defaults play stats toggle to off for invalid persisted values", () => {
+  localStorage.setItem(PLAY_STATS_STORAGE_KEY, "invalid");
+  mockSokoban({ state: State.playing });
+
+  render(<Game />);
+
+  expect(screen.queryByRole("region", { name: /play statistics/i })).not.toBeInTheDocument();
+});
+
+test("persists play stats toggle state when changed", () => {
+  mockSokoban({ state: State.playing });
+
+  render(<Game />);
+
+  expect(localStorage.getItem(PLAY_STATS_STORAGE_KEY)).toBe("false");
+
+  setPlayStatsVisibility(true);
+  expect(localStorage.getItem(PLAY_STATS_STORAGE_KEY)).toBe("true");
+
+  setPlayStatsVisibility(false);
+  expect(localStorage.getItem(PLAY_STATS_STORAGE_KEY)).toBe("false");
 });
 
 test("keeps completion dialog play stats hidden when toggle is off", () => {

--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -601,8 +601,8 @@ test("renders current run and level best placeholders when play stats toggle is 
     throw new Error("Expected stats rows to be paragraph elements");
   }
 
-  expect(currentRun).toHaveTextContent(/0\s*moves\s*in\s*0:00/);
-  expect(levelBest).toHaveTextContent(/No\s*record\s*yet/);
+  expect(currentRun).toHaveTextContent(/Moves\s*0\s*Time\s*0:00/);
+  expect(levelBest).toHaveTextContent(/Moves\s*--\s*Time\s*--:--/);
 });
 
 test("hides both play stats lines after disabling the toggle", () => {
@@ -633,7 +633,7 @@ test("renders realtime current run status from useSokoban", () => {
     throw new Error("Expected current run row to be a paragraph element");
   }
 
-  expect(currentRun).toHaveTextContent(/12\s*moves\s*in\s*1:14/);
+  expect(currentRun).toHaveTextContent(/Moves\s*12\s*Time\s*1:14/);
 });
 
 test("renders level best from useStats", () => {
@@ -677,7 +677,7 @@ test("renders level best from useStats", () => {
     throw new Error("Expected level best row to be a paragraph element");
   }
 
-  expect(levelBestLine).toHaveTextContent(/9\s*moves\s*in\s*0:13/);
+  expect(levelBestLine).toHaveTextContent(/Moves\s*9\s*Time\s*0:13/);
   expect(screen.queryByText(/^Puzzle Best:/)).not.toBeInTheDocument();
 });
 
@@ -728,8 +728,8 @@ test("shows level best inside completion dialog", () => {
     throw new Error("Expected completion stats rows to be paragraph elements");
   }
 
-  expect(currentRun).toHaveTextContent(/0\s*moves\s*in\s*0:00/);
-  expect(levelBestLine).toHaveTextContent(/1\s*move\s*in\s*0:02/);
+  expect(currentRun).toHaveTextContent(/Moves\s*0\s*Time\s*0:00/);
+  expect(levelBestLine).toHaveTextContent(/Moves\s*1\s*Time\s*0:02/);
   expect(within(completionDialog).queryByText(/^Puzzle Best:/)).not.toBeInTheDocument();
 });
 

--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -570,8 +570,7 @@ test("hides play stats UI when toggle is off by default", () => {
 
   render(<Game />);
 
-  expect(screen.queryByText(/^Current Run:/)).not.toBeInTheDocument();
-  expect(screen.queryByText(/^Level Best:/)).not.toBeInTheDocument();
+  expect(screen.queryByRole("region", { name: /play statistics/i })).not.toBeInTheDocument();
 });
 
 test("keeps completion dialog play stats hidden when toggle is off", () => {
@@ -584,25 +583,25 @@ test("keeps completion dialog play stats hidden when toggle is off", () => {
   rerender(<Game />);
 
   const completionDialog = screen.getByRole("dialog", { name: /level completed/i });
-  expect(within(completionDialog).queryByText(/^Current Run:/)).not.toBeInTheDocument();
-  expect(within(completionDialog).queryByText(/^Level Best:/)).not.toBeInTheDocument();
+  expect(within(completionDialog).queryByText(/^Current$/)).not.toBeInTheDocument();
+  expect(within(completionDialog).queryByText(/^Best$/)).not.toBeInTheDocument();
 });
 
-test("renders current run and level best placeholders when play stats toggle is enabled", () => {
+test("renders current and best placeholders when play stats toggle is enabled", () => {
   mockSokoban({ state: State.playing });
 
   render(<Game />);
   setPlayStatsVisibility(true);
 
-  const currentRun = screen.getByText(/^Current Run:$/).closest("p");
-  const levelBest = screen.getByText(/^Level Best:$/).closest("p");
+  const currentRun = screen.getByText(/^Current$/).closest("p");
+  const levelBest = screen.getByText(/^Best$/).closest("p");
 
   if (!currentRun || !levelBest) {
     throw new Error("Expected stats rows to be paragraph elements");
   }
 
-  expect(currentRun).toHaveTextContent(/Moves\s*0\s*Time\s*0:00/);
-  expect(levelBest).toHaveTextContent(/Moves\s*--\s*Time\s*--:--/);
+  expect(currentRun).toHaveAttribute("aria-label", "Current: Moves 0 Time 0:00");
+  expect(levelBest).toHaveAttribute("aria-label", "Best: Moves -- Time --:--");
 });
 
 test("hides both play stats lines after disabling the toggle", () => {
@@ -610,12 +609,12 @@ test("hides both play stats lines after disabling the toggle", () => {
 
   render(<Game />);
   setPlayStatsVisibility(true);
-  expect(screen.getByText(/^Current Run:/)).toBeInTheDocument();
-  expect(screen.getByText(/^Level Best:/)).toBeInTheDocument();
+  expect(screen.getByText(/^Current$/)).toBeInTheDocument();
+  expect(screen.getByText(/^Best$/)).toBeInTheDocument();
 
   setPlayStatsVisibility(false);
-  expect(screen.queryByText(/^Current Run:/)).not.toBeInTheDocument();
-  expect(screen.queryByText(/^Level Best:/)).not.toBeInTheDocument();
+  expect(screen.queryByText(/^Current$/)).not.toBeInTheDocument();
+  expect(screen.queryByText(/^Best$/)).not.toBeInTheDocument();
 });
 
 test("renders realtime current run status from useSokoban", () => {
@@ -628,15 +627,15 @@ test("renders realtime current run status from useSokoban", () => {
   render(<Game />);
   setPlayStatsVisibility(true);
 
-  const currentRun = screen.getByText(/^Current Run:$/).closest("p");
+  const currentRun = screen.getByText(/^Current$/).closest("p");
   if (!currentRun) {
     throw new Error("Expected current run row to be a paragraph element");
   }
 
-  expect(currentRun).toHaveTextContent(/Moves\s*12\s*Time\s*1:14/);
+  expect(currentRun).toHaveAttribute("aria-label", "Current: Moves 12 Time 1:14");
 });
 
-test("renders level best from useStats", () => {
+test("renders best row from useStats", () => {
   const level = buildLevel();
 
   mockedUseStats.mockReturnValue(
@@ -672,16 +671,16 @@ test("renders level best from useStats", () => {
   render(<Game />);
   setPlayStatsVisibility(true);
 
-  const levelBestLine = screen.getByText(/^Level Best:$/).closest("p");
+  const levelBestLine = screen.getByText(/^Best$/).closest("p");
   if (!levelBestLine) {
-    throw new Error("Expected level best row to be a paragraph element");
+    throw new Error("Expected best row to be a paragraph element");
   }
 
-  expect(levelBestLine).toHaveTextContent(/Moves\s*9\s*Time\s*0:13/);
+  expect(levelBestLine).toHaveAttribute("aria-label", "Best: Moves 9 Time 0:13");
   expect(screen.queryByText(/^Puzzle Best:/)).not.toBeInTheDocument();
 });
 
-test("shows level best inside completion dialog", () => {
+test("shows best row inside completion dialog", () => {
   const level = buildLevel();
 
   mockedUseStats.mockReturnValue(
@@ -721,15 +720,15 @@ test("shows level best inside completion dialog", () => {
   rerender(<Game />);
 
   const completionDialog = screen.getByRole("dialog", { name: /level completed/i });
-  const currentRun = within(completionDialog).getByText(/^Current Run:$/).closest("p");
-  const levelBestLine = within(completionDialog).getByText(/^Level Best:$/).closest("p");
+  const currentRun = within(completionDialog).getByText(/^Current$/).closest("p");
+  const levelBestLine = within(completionDialog).getByText(/^Best$/).closest("p");
 
   if (!currentRun || !levelBestLine) {
     throw new Error("Expected completion stats rows to be paragraph elements");
   }
 
-  expect(currentRun).toHaveTextContent(/Moves\s*0\s*Time\s*0:00/);
-  expect(levelBestLine).toHaveTextContent(/Moves\s*1\s*Time\s*0:02/);
+  expect(currentRun).toHaveAttribute("aria-label", "Current: Moves 0 Time 0:00");
+  expect(levelBestLine).toHaveAttribute("aria-label", "Best: Moves 1 Time 0:02");
   expect(within(completionDialog).queryByText(/^Puzzle Best:/)).not.toBeInTheDocument();
 });
 

--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -570,8 +570,8 @@ test("hides play stats UI when toggle is off by default", () => {
 
   render(<Game />);
 
-  expect(screen.queryByText("Current Run: 0 moves in 0:00")).not.toBeInTheDocument();
-  expect(screen.queryByText("Level Best: No record yet")).not.toBeInTheDocument();
+  expect(screen.queryByText(/^Current Run:/)).not.toBeInTheDocument();
+  expect(screen.queryByText(/^Level Best:/)).not.toBeInTheDocument();
 });
 
 test("keeps completion dialog play stats hidden when toggle is off", () => {
@@ -594,8 +594,15 @@ test("renders current run and level best placeholders when play stats toggle is 
   render(<Game />);
   setPlayStatsVisibility(true);
 
-  expect(screen.getByText("Current Run: 0 moves in 0:00")).toBeInTheDocument();
-  expect(screen.getByText("Level Best: No record yet")).toBeInTheDocument();
+  const currentRun = screen.getByText(/^Current Run:$/).closest("p");
+  const levelBest = screen.getByText(/^Level Best:$/).closest("p");
+
+  if (!currentRun || !levelBest) {
+    throw new Error("Expected stats rows to be paragraph elements");
+  }
+
+  expect(currentRun).toHaveTextContent(/0\s*moves\s*in\s*0:00/);
+  expect(levelBest).toHaveTextContent(/No\s*record\s*yet/);
 });
 
 test("hides both play stats lines after disabling the toggle", () => {
@@ -603,12 +610,12 @@ test("hides both play stats lines after disabling the toggle", () => {
 
   render(<Game />);
   setPlayStatsVisibility(true);
-  expect(screen.getByText("Current Run: 0 moves in 0:00")).toBeInTheDocument();
-  expect(screen.getByText("Level Best: No record yet")).toBeInTheDocument();
+  expect(screen.getByText(/^Current Run:/)).toBeInTheDocument();
+  expect(screen.getByText(/^Level Best:/)).toBeInTheDocument();
 
   setPlayStatsVisibility(false);
-  expect(screen.queryByText("Current Run: 0 moves in 0:00")).not.toBeInTheDocument();
-  expect(screen.queryByText("Level Best: No record yet")).not.toBeInTheDocument();
+  expect(screen.queryByText(/^Current Run:/)).not.toBeInTheDocument();
+  expect(screen.queryByText(/^Level Best:/)).not.toBeInTheDocument();
 });
 
 test("renders realtime current run status from useSokoban", () => {
@@ -621,7 +628,12 @@ test("renders realtime current run status from useSokoban", () => {
   render(<Game />);
   setPlayStatsVisibility(true);
 
-  expect(screen.getByText("Current Run: 12 moves in 1:14")).toBeInTheDocument();
+  const currentRun = screen.getByText(/^Current Run:$/).closest("p");
+  if (!currentRun) {
+    throw new Error("Expected current run row to be a paragraph element");
+  }
+
+  expect(currentRun).toHaveTextContent(/12\s*moves\s*in\s*1:14/);
 });
 
 test("renders level best from useStats", () => {
@@ -660,7 +672,12 @@ test("renders level best from useStats", () => {
   render(<Game />);
   setPlayStatsVisibility(true);
 
-  expect(screen.getByText("Level Best: 9 moves in 0:13")).toBeInTheDocument();
+  const levelBestLine = screen.getByText(/^Level Best:$/).closest("p");
+  if (!levelBestLine) {
+    throw new Error("Expected level best row to be a paragraph element");
+  }
+
+  expect(levelBestLine).toHaveTextContent(/9\s*moves\s*in\s*0:13/);
   expect(screen.queryByText(/^Puzzle Best:/)).not.toBeInTheDocument();
 });
 
@@ -704,8 +721,15 @@ test("shows level best inside completion dialog", () => {
   rerender(<Game />);
 
   const completionDialog = screen.getByRole("dialog", { name: /level completed/i });
-  expect(within(completionDialog).getByText("Current Run: 0 moves in 0:00")).toBeInTheDocument();
-  expect(within(completionDialog).getByText("Level Best: 1 move in 0:02")).toBeInTheDocument();
+  const currentRun = within(completionDialog).getByText(/^Current Run:$/).closest("p");
+  const levelBestLine = within(completionDialog).getByText(/^Level Best:$/).closest("p");
+
+  if (!currentRun || !levelBestLine) {
+    throw new Error("Expected completion stats rows to be paragraph elements");
+  }
+
+  expect(currentRun).toHaveTextContent(/0\s*moves\s*in\s*0:00/);
+  expect(levelBestLine).toHaveTextContent(/1\s*move\s*in\s*0:02/);
   expect(within(completionDialog).queryByText(/^Puzzle Best:/)).not.toBeInTheDocument();
 });
 

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -26,6 +26,39 @@ function formatMoveLabel(moves: number): string {
   return `${moves} ${moves === 1 ? "move" : "moves"}`;
 }
 
+type StatsRowProps = {
+  className: string;
+  label: string;
+  moves: number | null;
+  timeMs: number | null;
+};
+
+function StatsRow({ className, label, moves, timeMs }: StatsRowProps) {
+  if (moves === null || timeMs === null) {
+    return (
+      <p className={className} aria-label={`${label}: No record yet`}>
+        <span className={style.statsLabel}>{label}:</span>
+        <span className={style.statsNoRecord}>No record yet</span>
+      </p>
+    );
+  }
+
+  return (
+    <p
+      className={className}
+      aria-label={`${label}: ${formatMoveLabel(moves)} in ${formatElapsedTime(timeMs)}`}
+    >
+      <span className={style.statsLabel}>{label}:</span>
+      <span className={style.statsMetric}>
+        <span className={style.statsMoveCount}>{moves}</span>
+        <span className={style.statsMoveWord}>{moves === 1 ? "move" : "moves"}</span>
+        <span className={style.statsInWord}>in</span>
+        <span className={style.statsTimeValue}>{formatElapsedTime(timeMs)}</span>
+      </span>
+    </p>
+  );
+}
+
 function useHoldToRepeat(
   action: () => void,
   delay = 320,
@@ -476,17 +509,12 @@ function Game() {
     return `${currentPackLevelNumber} / ${currentPack.levels.length}`;
   }, [currentPack, currentPackLevelIndex, index, levelCount]);
   const levelBest = stats.progression[level.levelId];
-  const levelBestText = React.useMemo(() => {
-    if (!levelBest || levelBest.bestMovesInLevel === null || levelBest.bestTimeMsInLevel === null) {
-      return "Level Best: No record yet";
-    }
-
-    return `Level Best: ${formatMoveLabel(levelBest.bestMovesInLevel)} in ${formatElapsedTime(levelBest.bestTimeMsInLevel)}`;
-  }, [levelBest]);
-  const currentRunText = React.useMemo(
-    () => `Current Run: ${formatMoveLabel(moveCount)} in ${formatElapsedTime(elapsedTimeMs)}`,
-    [elapsedTimeMs, moveCount]
-  );
+  const hasLevelBestRecord =
+    levelBest !== undefined &&
+    levelBest.bestMovesInLevel !== null &&
+    levelBest.bestTimeMsInLevel !== null;
+  const levelBestMoves = hasLevelBestRecord ? levelBest.bestMovesInLevel : null;
+  const levelBestTimeMs = hasLevelBestRecord ? levelBest.bestTimeMsInLevel : null;
 
   useKeyBoard(
     (event) => {
@@ -644,8 +672,8 @@ function Game() {
 
       {showPlayStats && (
         <section className={style.bestStatsBar} aria-label="Play statistics">
-          <p className={style.bestStatsChip}>{currentRunText}</p>
-          <p className={style.bestStatsChip}>{levelBestText}</p>
+          <StatsRow className={style.bestStatsChip} label="Current Run" moves={moveCount} timeMs={elapsedTimeMs} />
+          <StatsRow className={style.bestStatsChip} label="Level Best" moves={levelBestMoves} timeMs={levelBestTimeMs} />
         </section>
       )}
 
@@ -757,8 +785,8 @@ function Game() {
             )}
             {showPlayStats && (
               <div className={style.completionStats} aria-label="Run and best records">
-                <p className={style.completionStatsLine}>{currentRunText}</p>
-                <p className={style.completionStatsLine}>{levelBestText}</p>
+                <StatsRow className={style.completionStatsLine} label="Current Run" moves={moveCount} timeMs={elapsedTimeMs} />
+                <StatsRow className={style.completionStatsLine} label="Level Best" moves={levelBestMoves} timeMs={levelBestTimeMs} />
               </div>
             )}
             <button type="button" className={style.completionButton} onClick={next}>

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -22,10 +22,6 @@ function formatElapsedTime(timeMs: number): string {
   return `${minutes}:${String(seconds).padStart(2, "0")}`;
 }
 
-function formatMoveLabel(moves: number): string {
-  return `${moves} ${moves === 1 ? "move" : "moves"}`;
-}
-
 type StatsRowProps = {
   className: string;
   label: string;
@@ -34,26 +30,17 @@ type StatsRowProps = {
 };
 
 function StatsRow({ className, label, moves, timeMs }: StatsRowProps) {
-  if (moves === null || timeMs === null) {
-    return (
-      <p className={className} aria-label={`${label}: No record yet`}>
-        <span className={style.statsLabel}>{label}:</span>
-        <span className={style.statsNoRecord}>No record yet</span>
-      </p>
-    );
-  }
+  const moveValue = moves === null ? "--" : String(moves);
+  const timeValue = timeMs === null ? "--:--" : formatElapsedTime(timeMs);
 
   return (
-    <p
-      className={className}
-      aria-label={`${label}: ${formatMoveLabel(moves)} in ${formatElapsedTime(timeMs)}`}
-    >
+    <p className={className} aria-label={`${label}: Moves ${moveValue} Time ${timeValue}`}>
       <span className={style.statsLabel}>{label}:</span>
       <span className={style.statsMetric}>
-        <span className={style.statsMoveCount}>{moves}</span>
-        <span className={style.statsMoveWord}>{moves === 1 ? "move" : "moves"}</span>
-        <span className={style.statsInWord}>in</span>
-        <span className={style.statsTimeValue}>{formatElapsedTime(timeMs)}</span>
+        <span className={style.statsMetricLabel}>Moves</span>
+        <span className={style.statsMoveCount}>{moveValue}</span>
+        <span className={style.statsMetricLabel}>Time</span>
+        <span className={style.statsTimeValue}>{timeValue}</span>
       </span>
     </p>
   );

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -22,6 +22,20 @@ function formatElapsedTime(timeMs: number): string {
   return `${minutes}:${String(seconds).padStart(2, "0")}`;
 }
 
+export const PLAY_STATS_STORAGE_KEY = "sokoban-play-stats-visible";
+
+function parseStoredPlayStatsVisibility(value: string | null): boolean {
+  return value === "true";
+}
+
+function getInitialPlayStatsVisibility(): boolean {
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  return parseStoredPlayStatsVisibility(window.localStorage.getItem(PLAY_STATS_STORAGE_KEY));
+}
+
 type StatsTableProps = {
   rowClassName: string;
   currentMoves: number;
@@ -177,11 +191,19 @@ function Game() {
   const [tileSize, setTileSize] = React.useState(24);
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
   // Play statistics are optional HUD info; default off to keep the board area less noisy.
-  const [showPlayStats, setShowPlayStats] = React.useState(false);
+  const [showPlayStats, setShowPlayStats] = React.useState(getInitialPlayStatsVisibility);
   const [isHelpModalOpen, setIsHelpModalOpen] = React.useState(false);
   const [isSfxModalOpen, setIsSfxModalOpen] = React.useState(false);
   const [isLevelSelectorOpen, setIsLevelSelectorOpen] = React.useState(false);
   const isAuxModalOpen = isHelpModalOpen || isSfxModalOpen || isMenuOpen || isLevelSelectorOpen;
+
+  React.useEffect(() => {
+    if (typeof window === "undefined") {
+      return;
+    }
+
+    window.localStorage.setItem(PLAY_STATS_STORAGE_KEY, String(showPlayStats));
+  }, [showPlayStats]);
 
   type PendingAction =
     | { type: "restart" }

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -22,27 +22,38 @@ function formatElapsedTime(timeMs: number): string {
   return `${minutes}:${String(seconds).padStart(2, "0")}`;
 }
 
-type StatsRowProps = {
-  className: string;
-  label: string;
-  moves: number | null;
-  timeMs: number | null;
+type StatsTableProps = {
+  rowClassName: string;
+  currentMoves: number;
+  currentTimeMs: number;
+  bestMoves: number | null;
+  bestTimeMs: number | null;
 };
 
-function StatsRow({ className, label, moves, timeMs }: StatsRowProps) {
-  const moveValue = moves === null ? "--" : String(moves);
-  const timeValue = timeMs === null ? "--:--" : formatElapsedTime(timeMs);
+function StatsTable({ rowClassName, currentMoves, currentTimeMs, bestMoves, bestTimeMs }: StatsTableProps) {
+  const currentMoveValue = String(currentMoves);
+  const currentTimeValue = formatElapsedTime(currentTimeMs);
+  const bestMoveValue = bestMoves === null ? "--" : String(bestMoves);
+  const bestTimeValue = bestTimeMs === null ? "--:--" : formatElapsedTime(bestTimeMs);
 
   return (
-    <p className={className} aria-label={`${label}: Moves ${moveValue} Time ${timeValue}`}>
-      <span className={style.statsLabel}>{label}:</span>
-      <span className={style.statsMetric}>
-        <span className={style.statsMetricLabel}>Moves</span>
-        <span className={style.statsMoveCount}>{moveValue}</span>
-        <span className={style.statsMetricLabel}>Time</span>
-        <span className={style.statsTimeValue}>{timeValue}</span>
-      </span>
-    </p>
+    <>
+      <p className={rowClassName} aria-hidden="true">
+        <span className={style.statsHeaderCell}>Run</span>
+        <span className={style.statsHeaderCell}>Moves</span>
+        <span className={style.statsHeaderCell}>Time</span>
+      </p>
+      <p className={rowClassName} aria-label={`Current: Moves ${currentMoveValue} Time ${currentTimeValue}`}>
+        <span className={style.statsRunCell}>Current</span>
+        <span className={style.statsValueCell}>{currentMoveValue}</span>
+        <span className={style.statsValueCell}>{currentTimeValue}</span>
+      </p>
+      <p className={rowClassName} aria-label={`Best: Moves ${bestMoveValue} Time ${bestTimeValue}`}>
+        <span className={style.statsRunCell}>Best</span>
+        <span className={style.statsValueCell}>{bestMoveValue}</span>
+        <span className={style.statsValueCell}>{bestTimeValue}</span>
+      </p>
+    </>
   );
 }
 
@@ -358,7 +369,7 @@ function Game() {
       playLevelComplete();
 
       if (completionMetrics) {
-        // Keep dual-key persistence even though the UI currently shows only Level Best.
+        // Keep dual-key persistence even though the UI surfaces per-level Best values.
         // `levelId` powers player-facing per-level stats, while `puzzleId` keeps
         // cross-level puzzle records for future packs that may reuse layouts.
         saveLevelResult({
@@ -659,8 +670,13 @@ function Game() {
 
       {showPlayStats && (
         <section className={style.bestStatsBar} aria-label="Play statistics">
-          <StatsRow className={style.bestStatsChip} label="Current Run" moves={moveCount} timeMs={elapsedTimeMs} />
-          <StatsRow className={style.bestStatsChip} label="Level Best" moves={levelBestMoves} timeMs={levelBestTimeMs} />
+          <StatsTable
+            rowClassName={style.bestStatsRow}
+            currentMoves={moveCount}
+            currentTimeMs={elapsedTimeMs}
+            bestMoves={levelBestMoves}
+            bestTimeMs={levelBestTimeMs}
+          />
         </section>
       )}
 
@@ -772,8 +788,13 @@ function Game() {
             )}
             {showPlayStats && (
               <div className={style.completionStats} aria-label="Run and best records">
-                <StatsRow className={style.completionStatsLine} label="Current Run" moves={moveCount} timeMs={elapsedTimeMs} />
-                <StatsRow className={style.completionStatsLine} label="Level Best" moves={levelBestMoves} timeMs={levelBestTimeMs} />
+                <StatsTable
+                  rowClassName={style.completionStatsRow}
+                  currentMoves={moveCount}
+                  currentTimeMs={elapsedTimeMs}
+                  bestMoves={levelBestMoves}
+                  bestTimeMs={levelBestTimeMs}
+                />
               </div>
             )}
             <button type="button" className={style.completionButton} onClick={next}>

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -54,7 +54,7 @@
 }
 
 .bestStatsBar {
-    width: min(100%, 32ch);
+    width: min(100%, 30ch);
     max-width: 100%;
     box-sizing: border-box;
     display: flex;
@@ -71,63 +71,61 @@
     flex-shrink: 0;
 }
 
-.bestStatsChip {
+.bestStatsRow,
+.completionStatsRow {
     margin: 0;
     border: 0;
     background: none;
     color: inherit;
     padding: 0 0.25ch;
     display: grid;
-    grid-template-columns: 10.5ch auto;
-    column-gap: 0.6ch;
-    justify-content: center;
+    grid-template-columns: 1fr 5ch 7ch;
+    column-gap: 0.8ch;
     align-items: baseline;
-    font-size: 0.75rem;
-    font-weight: 700;
-    line-height: 1.1;
     text-align: left;
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
 }
 
-.statsLabel {
+.bestStatsRow {
+    font-size: 0.75rem;
+    font-weight: 700;
+    line-height: 1.1;
+}
+
+.completionStatsRow {
+    font-size: 0.8rem;
+    font-weight: 700;
+    line-height: 1.2;
+}
+
+.statsHeaderCell {
+    text-align: left;
+    font-size: 0.68em;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: color-mix(in srgb, var(--muted) 85%, var(--foreground) 15%);
+}
+
+.statsHeaderCell:nth-child(2),
+.statsHeaderCell:nth-child(3) {
     text-align: right;
-    white-space: nowrap;
 }
 
-.statsMetric {
-    display: grid;
-    grid-template-columns: 5ch 4ch 4ch 6ch;
-    column-gap: 0.35ch;
-    align-items: baseline;
-    justify-content: start;
-}
-
-.statsMetric> :nth-child(3) {
-    border-left: 1px solid color-mix(in srgb, var(--border) 70%, transparent 30%);
-    margin-left: 0.65ch;
-    padding-left: 0.7ch;
-}
-
-.statsMetric> :nth-child(4) {
-    padding-left: 0.2ch;
-}
-
-.statsMetricLabel {
+.statsRunCell {
     text-align: left;
     white-space: nowrap;
 }
 
-.statsMoveCount {
+.statsValueCell {
     text-align: right;
     white-space: nowrap;
 }
 
-.statsTimeValue {
-    text-align: right;
-    white-space: nowrap;
+.bestStatsRow,
+.completionStatsRow {
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 .menuToggleButton {
@@ -395,7 +393,7 @@
     display: flex;
     flex-direction: column;
     gap: 3px;
-    width: min(100%, 32ch);
+    width: min(100%, 30ch);
     max-width: 100%;
     box-sizing: border-box;
     margin: 4px auto 18px;
@@ -405,27 +403,6 @@
     color: var(--muted);
     padding: 5px 6px;
     text-align: center;
-}
-
-.completionStatsLine {
-    margin: 0;
-    border: 0;
-    background: none;
-    color: inherit;
-    padding: 0 0.25ch;
-    display: grid;
-    grid-template-columns: 10.5ch auto;
-    column-gap: 0.6ch;
-    justify-content: center;
-    align-items: baseline;
-    font-size: 0.8rem;
-    font-weight: 700;
-    line-height: 1.2;
-    text-align: left;
-    font-variant-numeric: tabular-nums;
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
 }
 
 .completionButton {

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -54,18 +54,19 @@
 }
 
 .bestStatsBar {
-    width: max-content;
+    width: min(100%, 34ch);
     max-width: 100%;
+    box-sizing: border-box;
     display: flex;
     flex-direction: column;
-    gap: 4px;
-    align-self: flex-start;
+    gap: 3px;
+    align-self: flex-end;
     margin: 0;
     border: 1px solid var(--border);
     border-radius: 12px;
     background: color-mix(in srgb, var(--surface) 90%, var(--text) 10%);
     color: var(--muted);
-    padding: 6px 10px;
+    padding: 5px 7px;
     text-align: center;
     flex-shrink: 0;
 }
@@ -75,15 +76,57 @@
     border: 0;
     background: none;
     color: inherit;
-    padding: 0;
+    padding: 0 0.5ch;
+    display: grid;
+    grid-template-columns: 12ch auto;
+    column-gap: 0.75ch;
+    justify-content: center;
+    align-items: baseline;
     font-size: 0.75rem;
     font-weight: 700;
     line-height: 1.1;
-    text-align: center;
+    text-align: left;
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
+}
+
+.statsLabel {
+    text-align: right;
+    white-space: nowrap;
+}
+
+.statsMetric {
+    display: grid;
+    grid-template-columns: 4ch 5ch 2ch 8ch;
+    column-gap: 0.6ch;
+    align-items: baseline;
+    justify-content: start;
+}
+
+.statsMoveCount {
+    text-align: right;
+}
+
+.statsMoveWord,
+.statsInWord {
+    text-align: left;
+    white-space: nowrap;
+}
+
+.statsInWord {
+    padding-left: 0.15ch;
+}
+
+.statsTimeValue {
+    text-align: right;
+    white-space: nowrap;
+}
+
+.statsNoRecord {
+    text-align: left;
+    white-space: nowrap;
 }
 
 .menuToggleButton {
@@ -350,15 +393,16 @@
 .completionStats {
     display: flex;
     flex-direction: column;
-    gap: 4px;
-    width: max-content;
+    gap: 3px;
+    width: min(100%, 34ch);
     max-width: 100%;
+    box-sizing: border-box;
     margin: 4px auto 18px;
     border: 1px solid var(--border);
     border-radius: 12px;
     background: color-mix(in srgb, var(--surface) 90%, var(--text) 10%);
     color: var(--muted);
-    padding: 6px 10px;
+    padding: 5px 7px;
     text-align: center;
 }
 
@@ -367,11 +411,16 @@
     border: 0;
     background: none;
     color: inherit;
-    padding: 0;
+    padding: 0 0.5ch;
+    display: grid;
+    grid-template-columns: 12ch auto;
+    column-gap: 0.75ch;
+    justify-content: center;
+    align-items: baseline;
     font-size: 0.8rem;
     font-weight: 700;
     line-height: 1.2;
-    text-align: center;
+    text-align: left;
     font-variant-numeric: tabular-nums;
     white-space: nowrap;
     overflow: hidden;

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -54,7 +54,7 @@
 }
 
 .bestStatsBar {
-    width: min(100%, 34ch);
+    width: min(100%, 32ch);
     max-width: 100%;
     box-sizing: border-box;
     display: flex;
@@ -66,7 +66,7 @@
     border-radius: 12px;
     background: color-mix(in srgb, var(--surface) 90%, var(--text) 10%);
     color: var(--muted);
-    padding: 5px 7px;
+    padding: 5px 6px;
     text-align: center;
     flex-shrink: 0;
 }
@@ -76,10 +76,10 @@
     border: 0;
     background: none;
     color: inherit;
-    padding: 0 0.5ch;
+    padding: 0 0.25ch;
     display: grid;
-    grid-template-columns: 12ch auto;
-    column-gap: 0.75ch;
+    grid-template-columns: 10.5ch auto;
+    column-gap: 0.6ch;
     justify-content: center;
     align-items: baseline;
     font-size: 0.75rem;
@@ -99,33 +99,34 @@
 
 .statsMetric {
     display: grid;
-    grid-template-columns: 4ch 5ch 2ch 8ch;
-    column-gap: 0.6ch;
+    grid-template-columns: 5ch 4ch 4ch 6ch;
+    column-gap: 0.35ch;
     align-items: baseline;
     justify-content: start;
 }
 
-.statsMoveCount {
-    text-align: right;
+.statsMetric> :nth-child(3) {
+    border-left: 1px solid color-mix(in srgb, var(--border) 70%, transparent 30%);
+    margin-left: 0.65ch;
+    padding-left: 0.7ch;
 }
 
-.statsMoveWord,
-.statsInWord {
+.statsMetric> :nth-child(4) {
+    padding-left: 0.2ch;
+}
+
+.statsMetricLabel {
     text-align: left;
     white-space: nowrap;
 }
 
-.statsInWord {
-    padding-left: 0.15ch;
+.statsMoveCount {
+    text-align: right;
+    white-space: nowrap;
 }
 
 .statsTimeValue {
     text-align: right;
-    white-space: nowrap;
-}
-
-.statsNoRecord {
-    text-align: left;
     white-space: nowrap;
 }
 
@@ -394,7 +395,7 @@
     display: flex;
     flex-direction: column;
     gap: 3px;
-    width: min(100%, 34ch);
+    width: min(100%, 32ch);
     max-width: 100%;
     box-sizing: border-box;
     margin: 4px auto 18px;
@@ -402,7 +403,7 @@
     border-radius: 12px;
     background: color-mix(in srgb, var(--surface) 90%, var(--text) 10%);
     color: var(--muted);
-    padding: 5px 7px;
+    padding: 5px 6px;
     text-align: center;
 }
 
@@ -411,10 +412,10 @@
     border: 0;
     background: none;
     color: inherit;
-    padding: 0 0.5ch;
+    padding: 0 0.25ch;
     display: grid;
-    grid-template-columns: 12ch auto;
-    column-gap: 0.75ch;
+    grid-template-columns: 10.5ch auto;
+    column-gap: 0.6ch;
     justify-content: center;
     align-items: baseline;
     font-size: 0.8rem;


### PR DESCRIPTION
### Description
This Pull Request introduces the user interface components necessary to display performance statistics during gameplay. It refactors the stats layout for better readability, introduces a dedicated rendering component for metrics, and implements a persistent toggle so players can save their visibility preferences across sessions.

### Key Changes
* **StatsRow Component:** Introduced a new `StatsRow` component to cleanly render "current run" and "level best" statistics side-by-side. This abstracts the rendering logic out of the main `Game` component for better maintainability.
* **Persistent Visibility Toggle:** Added a user-facing toggle to show or hide the play statistics display. The chosen state is saved to `localStorage` via newly introduced helper functions, ensuring the preference is remembered upon reloading the game.
* **UI and Styling Enhancements:** Refactored the CSS to improve the structural layout, alignment, and overall visual presentation of the in-game statistics.