### PR TITLE
feat: enhance completion overlays and level selector navigation

### DIFF
--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -409,8 +409,8 @@ test("long press does not enable text selection on nav, modal, or completion but
   const completionButton = screen.getByRole("button", { name: "Continue" });
 
   fireEvent.pointerDown(completionButton, { button: 0, pointerId: 6 });
-  expect(completionButton).toHaveClass(style.completionButton);
-  expect(hasUserSelectNone("completionButton")).toBe(true);
+  expect(completionButton).toHaveClass(style.levelNavButton);
+  expect(hasUserSelectNone("levelNavButton")).toBe(true);
 });
 
 test("keyboard bracket-right opens confirmation when progress exists", () => {
@@ -564,6 +564,15 @@ test("displays completion popup when level is completed", () => {
   expect(screen.getByText(/you completed this level\./i)).toBeInTheDocument();
   expect(screen.getByRole("button", { name: /continue/i })).toBeInTheDocument();
   expect(screen.getByTestId("mobile-controls")).toBeInTheDocument();
+});
+
+test("focuses Continue by default on non-pack-complete completion popup", () => {
+  mockSokoban({ state: State.completed });
+
+  render(<Game />);
+
+  expect(screen.queryByRole("button", { name: /level packs/i })).not.toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /continue/i })).toHaveFocus();
 });
 
 test("hides play stats UI when toggle is off by default", () => {
@@ -781,9 +790,94 @@ test("displays pack-complete message on the last level of the current pack", () 
   expect(screen.getByText(/you completed the last level in this pack\./i)).toBeInTheDocument();
   expect(screen.getByText(/switch to a different level pack/i)).toBeInTheDocument();
   const levelPacksButton = screen.getByRole("button", { name: /level packs/i });
+  const continueButton = screen.getByRole("button", { name: /continue/i });
   expect(levelPacksButton).toBeInTheDocument();
   expect(levelPacksButton).toHaveFocus();
-  expect(screen.getByRole("button", { name: /continue/i })).toBeInTheDocument();
+  expect(continueButton).toBeInTheDocument();
+  expect(continueButton).toHaveClass(style.levelNavButton);
+});
+
+test("arrow keys move focus between Level Packs and Continue on pack-complete popup", () => {
+  const levelPacks = buildLevelPacks();
+  mockSokoban({
+    state: State.completed,
+    level: levelPacks[0].levels[1],
+    levelPacks,
+  });
+
+  render(<Game />);
+
+  const levelPacksButton = screen.getByRole("button", { name: /level packs/i });
+  const continueButton = screen.getByRole("button", { name: /continue/i });
+  expect(levelPacksButton).toHaveFocus();
+
+  const onKeyboardEvent = getLatestKeyboardHandler();
+  const { event: rightEvent, preventDefaultSpy: rightPreventDefault } = createKeyboardEvent("ArrowRight");
+
+  act(() => {
+    onKeyboardEvent(rightEvent);
+  });
+
+  expect(continueButton).toHaveFocus();
+  expect(rightPreventDefault).toHaveBeenCalledTimes(1);
+
+  const { event: leftEvent, preventDefaultSpy: leftPreventDefault } = createKeyboardEvent("ArrowLeft");
+
+  act(() => {
+    onKeyboardEvent(leftEvent);
+  });
+
+  expect(levelPacksButton).toHaveFocus();
+  expect(leftPreventDefault).toHaveBeenCalledTimes(1);
+});
+
+test("pressing Enter on pack-complete popup opens level selector when Level Packs is focused", () => {
+  const next = vi.fn();
+  const levelPacks = buildLevelPacks();
+  mockSokoban({
+    state: State.completed,
+    next,
+    level: levelPacks[0].levels[1],
+    levelPacks,
+  });
+
+  render(<Game />);
+
+  const onKeyboardEvent = getLatestKeyboardHandler();
+  const { event, preventDefaultSpy } = createKeyboardEvent("Enter");
+
+  act(() => {
+    onKeyboardEvent(event);
+  });
+
+  expect(screen.getByRole("dialog", { name: /level pack selector/i })).toBeInTheDocument();
+  expect(next).not.toHaveBeenCalled();
+  expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
+});
+
+test("pressing Enter on pack-complete popup advances when Continue is focused", () => {
+  const next = vi.fn();
+  const levelPacks = buildLevelPacks();
+  mockSokoban({
+    state: State.completed,
+    next,
+    level: levelPacks[0].levels[1],
+    levelPacks,
+  });
+
+  render(<Game />);
+  const continueButton = screen.getByRole("button", { name: /continue/i });
+  continueButton.focus();
+
+  const onKeyboardEvent = getLatestKeyboardHandler();
+  const { event, preventDefaultSpy } = createKeyboardEvent("Enter");
+
+  act(() => {
+    onKeyboardEvent(event);
+  });
+
+  expect(next).toHaveBeenCalledTimes(1);
+  expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
 });
 
 test("opens level selector modal from pack-complete completion popup", () => {
@@ -821,6 +915,23 @@ test("pressing Enter on completion popup advances to next level", () => {
 
   const onKeyboardEvent = getLatestKeyboardHandler();
   const { event, preventDefaultSpy } = createKeyboardEvent("Enter");
+
+  act(() => {
+    onKeyboardEvent(event);
+  });
+
+  expect(next).toHaveBeenCalledTimes(1);
+  expect(preventDefaultSpy).toHaveBeenCalledTimes(1);
+});
+
+test("pressing Space on completion popup advances to next level", () => {
+  const next = vi.fn();
+  mockSokoban({ state: State.completed, next });
+
+  render(<Game />);
+
+  const onKeyboardEvent = getLatestKeyboardHandler();
+  const { event, preventDefaultSpy } = createKeyboardEvent("Space");
 
   act(() => {
     onKeyboardEvent(event);

--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -1252,7 +1252,7 @@ test("menu blocks movement keys and escape closes the menu", () => {
   expect(screen.queryByRole("dialog", { name: /game menu/i })).not.toBeInTheDocument();
 });
 
-test("menu actions open sfx and about dialogs", () => {
+test("menu actions open sfx, level selector, and about dialogs", () => {
   mockSokoban();
 
   render(<Game />);
@@ -1262,6 +1262,15 @@ test("menu actions open sfx and about dialogs", () => {
 
   expect(screen.getByTestId("sfx-settings")).toHaveAttribute("data-open", "true");
   expect(screen.queryByRole("dialog", { name: /game menu/i })).not.toBeInTheDocument();
+
+  fireEvent.click(screen.getByRole("button", { name: /open menu/i }));
+  fireEvent.click(screen.getByRole("button", { name: /level packs/i }));
+
+  const levelSelectorDialog = screen.getByRole("dialog", { name: /level pack selector/i });
+  expect(levelSelectorDialog).toBeInTheDocument();
+  expect(screen.queryByRole("dialog", { name: /game menu/i })).not.toBeInTheDocument();
+
+  fireEvent.click(within(levelSelectorDialog).getByRole("button", { name: /^close$/i }));
 
   fireEvent.click(screen.getByRole("button", { name: /open menu/i }));
   fireEvent.click(screen.getByRole("button", { name: /^about$/i }));

--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -780,6 +780,26 @@ test("displays pack-complete message on the last level of the current pack", () 
   expect(screen.getByRole("heading", { name: /level pack complete!/i })).toBeInTheDocument();
   expect(screen.getByText(/you completed the last level in this pack\./i)).toBeInTheDocument();
   expect(screen.getByText(/switch to a different level pack/i)).toBeInTheDocument();
+  const levelPacksButton = screen.getByRole("button", { name: /level packs/i });
+  expect(levelPacksButton).toBeInTheDocument();
+  expect(levelPacksButton).toHaveFocus();
+  expect(screen.getByRole("button", { name: /continue/i })).toBeInTheDocument();
+});
+
+test("opens level selector modal from pack-complete completion popup", () => {
+  const levelPacks = buildLevelPacks();
+  mockSokoban({
+    state: State.completed,
+    level: levelPacks[0].levels[1],
+    levelPacks,
+  });
+
+  render(<Game />);
+
+  fireEvent.click(screen.getByRole("button", { name: /level packs/i }));
+
+  expect(screen.getByRole("dialog", { name: /level pack selector/i })).toBeInTheDocument();
+  expect(screen.queryByRole("dialog", { name: /level completed/i })).not.toBeInTheDocument();
 });
 
 test("clicking continue on completion popup advances to the next level", () => {

--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -829,6 +829,33 @@ test("arrow keys move focus between Level Packs and Continue on pack-complete po
 
   expect(levelPacksButton).toHaveFocus();
   expect(leftPreventDefault).toHaveBeenCalledTimes(1);
+
+  const { event: leftEdgeEvent, preventDefaultSpy: leftEdgePreventDefault } = createKeyboardEvent("ArrowLeft");
+
+  act(() => {
+    onKeyboardEvent(leftEdgeEvent);
+  });
+
+  expect(levelPacksButton).toHaveFocus();
+  expect(leftEdgePreventDefault).toHaveBeenCalledTimes(1);
+
+  const { event: rightAgainEvent, preventDefaultSpy: rightAgainPreventDefault } = createKeyboardEvent("ArrowRight");
+
+  act(() => {
+    onKeyboardEvent(rightAgainEvent);
+  });
+
+  expect(continueButton).toHaveFocus();
+  expect(rightAgainPreventDefault).toHaveBeenCalledTimes(1);
+
+  const { event: rightEdgeEvent, preventDefaultSpy: rightEdgePreventDefault } = createKeyboardEvent("ArrowRight");
+
+  act(() => {
+    onKeyboardEvent(rightEdgeEvent);
+  });
+
+  expect(continueButton).toHaveFocus();
+  expect(rightEdgePreventDefault).toHaveBeenCalledTimes(1);
 });
 
 test("pressing Enter on pack-complete popup opens level selector when Level Packs is focused", () => {
@@ -894,6 +921,8 @@ test("opens level selector modal from pack-complete completion popup", () => {
 
   expect(screen.getByRole("dialog", { name: /level pack selector/i })).toBeInTheDocument();
   expect(screen.queryByRole("dialog", { name: /level completed/i })).not.toBeInTheDocument();
+  expect(screen.getByRole("button", { name: /play pack/i })).toHaveFocus();
+  expect(screen.getByRole("button", { name: /^close$/i })).not.toHaveFocus();
 });
 
 test("clicking continue on completion popup advances to the next level", () => {
@@ -996,6 +1025,127 @@ test("opens level selector modal from level number button", () => {
   expect(screen.getByRole("heading", { name: "Test Pack" })).toBeInTheDocument();
   expect(screen.getByText("2 levels available")).toBeInTheDocument();
   expect(screen.queryByRole("button", { name: /open test pack level/i })).not.toBeInTheDocument();
+});
+
+test("arrow keys move focus between level packs in selector", () => {
+  const firstPack = buildLevelPacks()[0];
+  const secondPack = {
+    ...firstPack,
+    packId: "test-pack-2",
+    title: "Second Pack",
+    levels: [{ ...firstPack.levels[0], packId: "test-pack-2", levelId: "test-pack-2:0" }],
+  };
+  const levelPacks = [firstPack, secondPack];
+
+  mockSokoban({ levelPacks, level: firstPack.levels[0] });
+
+  render(<Game />);
+  fireEvent.click(screen.getByRole("button", { name: /open level selector/i }));
+
+  const playPackButtons = screen.getAllByRole("button", { name: "Play Pack" });
+  expect(playPackButtons).toHaveLength(2);
+  expect(playPackButtons[0]).toHaveFocus();
+
+  const onKeyboardEvent = getLatestKeyboardHandler();
+  const { event: rightEvent, preventDefaultSpy: rightPreventDefault } = createKeyboardEvent("ArrowRight");
+
+  act(() => {
+    onKeyboardEvent(rightEvent);
+  });
+
+  expect(playPackButtons[1]).toHaveFocus();
+  expect(rightPreventDefault).toHaveBeenCalledTimes(1);
+
+  const { event: leftEvent, preventDefaultSpy: leftPreventDefault } = createKeyboardEvent("ArrowLeft");
+
+  act(() => {
+    onKeyboardEvent(leftEvent);
+  });
+
+  expect(playPackButtons[0]).toHaveFocus();
+  expect(leftPreventDefault).toHaveBeenCalledTimes(1);
+});
+
+test("pressing Enter in level selector activates focused level pack", () => {
+  const loadLevel = vi.fn();
+  const firstPack = buildLevelPacks()[0];
+  const secondPack = {
+    ...firstPack,
+    packId: "test-pack-2",
+    title: "Second Pack",
+    levels: [{ ...firstPack.levels[0], packId: "test-pack-2", levelId: "test-pack-2:0" }],
+  };
+  const levelPacks = [firstPack, secondPack];
+
+  mockSokoban({
+    hasProgress: false,
+    state: State.playing,
+    loadLevel,
+    levelPacks,
+    level: firstPack.levels[0],
+  });
+
+  render(<Game />);
+  fireEvent.click(screen.getByRole("button", { name: /open level selector/i }));
+
+  const onKeyboardEvent = getLatestKeyboardHandler();
+  act(() => {
+    onKeyboardEvent(createKeyboardEvent("ArrowRight").event);
+  });
+
+  const { event: enterEvent, preventDefaultSpy: enterPreventDefault } = createKeyboardEvent("Enter");
+
+  act(() => {
+    onKeyboardEvent(enterEvent);
+  });
+
+  expect(loadLevel).toHaveBeenCalledWith("test-pack-2:0");
+  expect(screen.queryByRole("dialog", { name: /level pack selector/i })).not.toBeInTheDocument();
+  expect(enterPreventDefault).toHaveBeenCalledTimes(1);
+});
+
+test("pressing Space in level selector activates focused level pack", () => {
+  const loadLevel = vi.fn();
+  const levelPacks = buildLevelPacks();
+  mockSokoban({
+    hasProgress: false,
+    state: State.playing,
+    loadLevel,
+    level: levelPacks[0].levels[1],
+    levelPacks,
+  });
+
+  render(<Game />);
+  fireEvent.click(screen.getByRole("button", { name: /open level selector/i }));
+
+  const onKeyboardEvent = getLatestKeyboardHandler();
+  const { event: spaceEvent, preventDefaultSpy: spacePreventDefault } = createKeyboardEvent("Space");
+
+  act(() => {
+    onKeyboardEvent(spaceEvent);
+  });
+
+  expect(loadLevel).toHaveBeenCalledWith("test-pack:0");
+  expect(screen.queryByRole("dialog", { name: /level pack selector/i })).not.toBeInTheDocument();
+  expect(spacePreventDefault).toHaveBeenCalledTimes(1);
+});
+
+test("pressing Escape closes level selector modal", () => {
+  mockSokoban();
+
+  render(<Game />);
+  fireEvent.click(screen.getByRole("button", { name: /open level selector/i }));
+  expect(screen.getByRole("dialog", { name: /level pack selector/i })).toBeInTheDocument();
+
+  const onKeyboardEvent = getLatestKeyboardHandler();
+  const { event: escapeEvent, preventDefaultSpy: escapePreventDefault } = createKeyboardEvent("Escape");
+
+  act(() => {
+    onKeyboardEvent(escapeEvent);
+  });
+
+  expect(screen.queryByRole("dialog", { name: /level pack selector/i })).not.toBeInTheDocument();
+  expect(escapePreventDefault).toHaveBeenCalledTimes(1);
 });
 
 test("selecting a pack loads immediately when no progress exists", () => {

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -338,6 +338,11 @@ function Game() {
     setIsSfxModalOpen(true);
   }, []);
 
+  const onOpenLevelSelectorFromMenu = React.useCallback(() => {
+    setIsMenuOpen(false);
+    setIsLevelSelectorOpen(true);
+  }, []);
+
   const onOpenAboutFromMenu = React.useCallback(() => {
     setIsMenuOpen(false);
     setIsHelpModalOpen(true);
@@ -833,6 +838,7 @@ function Game() {
         onShowPlayStatsChange={setShowPlayStats}
         onClose={onCloseMenu}
         onOpenSfx={onOpenSfxFromMenu}
+        onOpenLevelSelector={onOpenLevelSelectorFromMenu}
         onOpenAbout={onOpenAboutFromMenu}
       />
 

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -323,6 +323,10 @@ function Game() {
     setIsLevelSelectorOpen(true);
   }, []);
 
+  const onOpenLevelSelectorFromCompletion = React.useCallback(() => {
+    setIsLevelSelectorOpen(true);
+  }, []);
+
   const onCloseMenu = React.useCallback(() => {
     setIsMenuOpen(false);
   }, []);
@@ -791,7 +795,7 @@ function Game() {
         </Modal>
       )}
 
-      {state === State.completed && (
+      {state === State.completed && !isLevelSelectorOpen && (
         <div className={style.completionOverlay} role="dialog" aria-modal="true" aria-label="Level completed">
           <div className={style.completionCard}>
             <h2 className={style.completionTitle}>
@@ -804,8 +808,8 @@ function Game() {
             </p>
             {isLastLevelInCurrentPack && (
               <p className={style.completionText}>
-                Switch to a different level pack from the level selector, or press Continue to
-                return to Level 1 in this pack.
+                Switch to a different level pack from the <span className={style.completionTextAccent}>Level Packs</span>
+                {" "}selector, or press <span className={style.completionTextAccent}>Continue</span> to return to Level 1 in this pack.
               </p>
             )}
             {showPlayStats && (
@@ -819,9 +823,25 @@ function Game() {
                 />
               </div>
             )}
-            <button type="button" className={style.completionButton} onClick={next}>
-              Continue
-            </button>
+            {isLastLevelInCurrentPack ? (
+              <div className={style.completionActions}>
+                <button
+                  type="button"
+                  className={style.levelNavButton}
+                  onClick={onOpenLevelSelectorFromCompletion}
+                  autoFocus
+                >
+                  Level Packs
+                </button>
+                <button type="button" className={style.completionButton} onClick={next}>
+                  Continue
+                </button>
+              </div>
+            ) : (
+              <button type="button" className={style.completionButton} onClick={next}>
+                Continue
+              </button>
+            )}
           </div>
         </div>
       )}

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -582,8 +582,53 @@ function Game() {
       }
 
       if (isLevelSelectorOpen) {
+        const selectablePackButtons = Array.from(
+          document.querySelectorAll(`.${style.levelSelectorPackPlayButton}`)
+        ).filter((button): button is HTMLButtonElement =>
+          button instanceof HTMLButtonElement && !button.disabled
+        );
+
         if (event.code === "Escape") {
           setIsLevelSelectorOpen(false);
+          event.preventDefault();
+          return;
+        }
+
+        if (
+          event.code === "ArrowUp" ||
+          event.code === "ArrowDown" ||
+          event.code === "ArrowLeft" ||
+          event.code === "ArrowRight"
+        ) {
+          if (selectablePackButtons.length > 0) {
+            const activeElement = document.activeElement;
+            const activeIndex =
+              activeElement instanceof HTMLButtonElement
+                ? selectablePackButtons.indexOf(activeElement)
+                : -1;
+            const delta = event.code === "ArrowUp" || event.code === "ArrowLeft" ? -1 : 1;
+            const nextIndex =
+              activeIndex >= 0
+                ? (activeIndex + delta + selectablePackButtons.length) % selectablePackButtons.length
+                : delta > 0
+                  ? 0
+                  : selectablePackButtons.length - 1;
+
+            selectablePackButtons[nextIndex].focus();
+          }
+
+          event.preventDefault();
+          return;
+        }
+
+        if (event.code === "Enter" || event.code === "Space") {
+          const activeElement = document.activeElement;
+
+          if (activeElement instanceof HTMLButtonElement && !activeElement.disabled) {
+            activeElement.click();
+          } else if (selectablePackButtons.length > 0) {
+            selectablePackButtons[0].click();
+          }
         }
 
         event.preventDefault();
@@ -599,13 +644,23 @@ function Game() {
         if (event.code === "ArrowLeft" || event.code === "ArrowRight") {
           if (isLastLevelInCurrentPack) {
             const activeElement = document.activeElement;
-            const targetButton =
-              activeElement === completionContinueButtonRef.current
-                ? completionLevelPacksButtonRef.current
-                : completionContinueButtonRef.current;
+            const levelPacksButton = completionLevelPacksButtonRef.current;
+            const continueButton = completionContinueButtonRef.current;
+            const isLevelPacksFocused = activeElement === levelPacksButton;
+            const isContinueFocused = activeElement === continueButton;
 
-            if (targetButton) {
-              targetButton.focus();
+            if (event.code === "ArrowRight") {
+              if (isLevelPacksFocused) {
+                continueButton?.focus();
+              } else if (!isContinueFocused) {
+                continueButton?.focus();
+              }
+            } else {
+              if (isContinueFocused) {
+                levelPacksButton?.focus();
+              } else if (!isLevelPacksFocused) {
+                levelPacksButton?.focus();
+              }
             }
           } else {
             completionContinueButtonRef.current?.focus();

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -188,6 +188,8 @@ function Game() {
   const boardViewportRef = React.useRef<HTMLDivElement | null>(null);
   const cancelButtonRef = React.useRef<HTMLButtonElement | null>(null);
   const confirmButtonRef = React.useRef<HTMLButtonElement | null>(null);
+  const completionContinueButtonRef = React.useRef<HTMLButtonElement | null>(null);
+  const completionLevelPacksButtonRef = React.useRef<HTMLButtonElement | null>(null);
   const [tileSize, setTileSize] = React.useState(24);
   const [isMenuOpen, setIsMenuOpen] = React.useState(false);
   // Play statistics are optional HUD info; default off to keep the board area less noisy.
@@ -593,6 +595,44 @@ function Game() {
         return;
       }
 
+      if (state === State.completed) {
+        if (event.code === "ArrowLeft" || event.code === "ArrowRight") {
+          if (isLastLevelInCurrentPack) {
+            const activeElement = document.activeElement;
+            const targetButton =
+              activeElement === completionContinueButtonRef.current
+                ? completionLevelPacksButtonRef.current
+                : completionContinueButtonRef.current;
+
+            if (targetButton) {
+              targetButton.focus();
+            }
+          } else {
+            completionContinueButtonRef.current?.focus();
+          }
+
+          event.preventDefault();
+          return;
+        }
+
+        if (event.code === "Enter" || event.code === "Space") {
+          const activeElement = document.activeElement;
+
+          if (
+            isLastLevelInCurrentPack &&
+            activeElement instanceof HTMLButtonElement &&
+            activeElement === completionLevelPacksButtonRef.current
+          ) {
+            onOpenLevelSelectorFromCompletion();
+          } else {
+            next();
+          }
+
+          event.preventDefault();
+          return;
+        }
+      }
+
       switch (event.code) {
         case "ArrowUp":
           onMove(Direction.Top);
@@ -630,6 +670,7 @@ function Game() {
       "ArrowLeft",
       "ArrowRight",
       "Enter",
+      "Space",
       "Backspace",
       "Escape",
       "BracketLeft",
@@ -830,15 +871,22 @@ function Game() {
                   className={style.levelNavButton}
                   onClick={onOpenLevelSelectorFromCompletion}
                   autoFocus
+                  ref={completionLevelPacksButtonRef}
                 >
                   Level Packs
                 </button>
-                <button type="button" className={style.completionButton} onClick={next}>
+                <button type="button" className={style.levelNavButton} onClick={next} ref={completionContinueButtonRef}>
                   Continue
                 </button>
               </div>
             ) : (
-              <button type="button" className={style.completionButton} onClick={next}>
+              <button
+                type="button"
+                className={style.levelNavButton}
+                onClick={next}
+                ref={completionContinueButtonRef}
+                autoFocus
+              >
                 Continue
               </button>
             )}

--- a/src/components/hamburger-menu.test.tsx
+++ b/src/components/hamburger-menu.test.tsx
@@ -21,6 +21,7 @@ function renderMenu(open = true, showPlayStats = false) {
     const onClose = vi.fn();
     const onShowPlayStatsChange = vi.fn();
     const onOpenSfx = vi.fn();
+    const onOpenLevelSelector = vi.fn();
     const onOpenAbout = vi.fn();
 
     const view = render(
@@ -30,6 +31,7 @@ function renderMenu(open = true, showPlayStats = false) {
             onShowPlayStatsChange={onShowPlayStatsChange}
             onClose={onClose}
             onOpenSfx={onOpenSfx}
+            onOpenLevelSelector={onOpenLevelSelector}
             onOpenAbout={onOpenAbout}
         />
     );
@@ -39,6 +41,7 @@ function renderMenu(open = true, showPlayStats = false) {
         onClose,
         onShowPlayStatsChange,
         onOpenSfx,
+        onOpenLevelSelector,
         onOpenAbout,
     };
 }
@@ -52,6 +55,7 @@ test("renders menu content and version", () => {
     expect(getByText("Show Play Stats")).toBeInTheDocument();
     expect(getByRole("checkbox", { name: /show play stats/i })).not.toBeChecked();
     expect(getByRole("button", { name: /sfx settings/i })).toBeInTheDocument();
+    expect(getByRole("button", { name: /level packs/i })).toBeInTheDocument();
     expect(getByRole("button", { name: /^about$/i })).toBeInTheDocument();
     expect(getByText(/version\s+1\.2\.3-test/i)).toBeInTheDocument();
 });
@@ -63,7 +67,7 @@ test("shows checked play stats toggle with hide aria label when enabled", () => 
 });
 
 test("applies open and hidden states based on open prop", () => {
-    const { rerender, container, onClose, onShowPlayStatsChange, onOpenAbout, onOpenSfx } = renderMenu(false);
+    const { rerender, container, onClose, onShowPlayStatsChange, onOpenAbout, onOpenSfx, onOpenLevelSelector } = renderMenu(false);
 
     let drawer = container.querySelector("#game-menu");
     if (!drawer) {
@@ -87,6 +91,7 @@ test("applies open and hidden states based on open prop", () => {
             onShowPlayStatsChange={onShowPlayStatsChange}
             onClose={onClose}
             onOpenSfx={onOpenSfx}
+            onOpenLevelSelector={onOpenLevelSelector}
             onOpenAbout={onOpenAbout}
         />
     );
@@ -107,7 +112,7 @@ test("applies open and hidden states based on open prop", () => {
 });
 
 test("menu actions call the expected callbacks", () => {
-    const { container, getByRole, onClose, onShowPlayStatsChange, onOpenSfx, onOpenAbout } = renderMenu(true);
+    const { container, getByRole, onClose, onShowPlayStatsChange, onOpenSfx, onOpenLevelSelector, onOpenAbout } = renderMenu(true);
 
     const backdrop = container.querySelector(`.${style.menuBackdrop}`);
     if (!backdrop) {
@@ -118,10 +123,12 @@ test("menu actions call the expected callbacks", () => {
     fireEvent.click(getByRole("button", { name: /close menu/i }));
     fireEvent.click(getByRole("checkbox", { name: /show play stats/i }));
     fireEvent.click(getByRole("button", { name: /sfx settings/i }));
+    fireEvent.click(getByRole("button", { name: /level packs/i }));
     fireEvent.click(getByRole("button", { name: /^about$/i }));
 
     expect(onClose).toHaveBeenCalledTimes(2);
     expect(onShowPlayStatsChange).toHaveBeenCalledWith(true);
     expect(onOpenSfx).toHaveBeenCalledTimes(1);
+    expect(onOpenLevelSelector).toHaveBeenCalledTimes(1);
     expect(onOpenAbout).toHaveBeenCalledTimes(1);
 });

--- a/src/components/hamburger-menu.tsx
+++ b/src/components/hamburger-menu.tsx
@@ -8,6 +8,7 @@ type HamburgerMenuProps = {
     onShowPlayStatsChange: (next: boolean) => void;
     onClose: () => void;
     onOpenSfx: () => void;
+    onOpenLevelSelector: () => void;
     onOpenAbout: () => void;
 };
 
@@ -17,6 +18,7 @@ function HamburgerMenuImpl({
     onShowPlayStatsChange,
     onClose,
     onOpenSfx,
+    onOpenLevelSelector,
     onOpenAbout,
 }: HamburgerMenuProps) {
     return (
@@ -74,6 +76,10 @@ function HamburgerMenuImpl({
 
                     <button type="button" className={style.menuItemButton} onClick={onOpenSfx}>
                         SFX Settings
+                    </button>
+
+                    <button type="button" className={style.menuItemButton} onClick={onOpenLevelSelector}>
+                        Level Packs
                     </button>
 
                     <button type="button" className={style.menuItemButton} onClick={onOpenAbout}>

--- a/src/components/level-selector-modal.tsx
+++ b/src/components/level-selector-modal.tsx
@@ -19,15 +19,16 @@ function LevelSelectorModal({
         return null;
     }
 
+    const firstPlayablePackIndex = levelPacks.findIndex((pack) => pack.levels.length > 0);
+
     return (
         <Modal
             title="Level Packs"
             ariaLabel="Level pack selector"
             onClose={() => onOpenChange(false)}
-            autoFocusCloseButton
         >
             <div className={style.levelSelector}>
-                {levelPacks.map((pack) => {
+                {levelPacks.map((pack, index) => {
                     const currentPackMeta = `${pack.levels.length} levels available`;
 
                     return (
@@ -47,6 +48,7 @@ function LevelSelectorModal({
                                         }
                                         onSelectLevel(pack.levels[0].levelId);
                                     }}
+                                    autoFocus={index === firstPlayablePackIndex}
                                     disabled={!pack.levels.length}
                                 >
                                     Play Pack

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -389,6 +389,11 @@
     color: var(--muted);
 }
 
+.completionTextAccent {
+    color: var(--accent);
+    font-weight: 700;
+}
+
 .completionStats {
     display: flex;
     flex-direction: column;
@@ -403,6 +408,14 @@
     color: var(--muted);
     padding: 5px 6px;
     text-align: center;
+}
+
+.completionActions {
+    display: flex;
+    justify-content: center;
+    align-items: center;
+    gap: 10px;
+    flex-wrap: wrap;
 }
 
 .completionButton {

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -592,7 +592,8 @@
 
 .menuToggleButton:hover,
 .menuDrawerCloseButton:hover,
-.menuItemButton:hover {
+.menuItemButton:hover,
+.modalCloseButton:hover {
     border-color: var(--accent);
 }
 
@@ -608,7 +609,8 @@
 
 .menuToggleButton:focus-visible,
 .menuDrawerCloseButton:focus-visible,
-.menuItemButton:focus-visible {
+.menuItemButton:focus-visible,
+.modalCloseButton:focus-visible {
     outline: 2px solid var(--accent);
     outline-offset: 2px;
 }

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -418,25 +418,6 @@
     flex-wrap: wrap;
 }
 
-.completionButton {
-    border: 1px solid var(--accent);
-    background: var(--accent);
-    color: var(--surface);
-    border-radius: 999px;
-    padding: 10px 18px;
-    font-weight: 800;
-    cursor: pointer;
-}
-
-.completionButton:hover {
-    filter: brightness(1.05);
-}
-
-.completionButton:focus-visible {
-    outline: 2px solid var(--accent);
-    outline-offset: 2px;
-}
-
 .menuBackdrop {
     position: fixed;
     inset: 0;
@@ -593,7 +574,6 @@
 .menuDrawerCloseButton,
 .menuItemButton,
 .levelSelectorLevelButton,
-.completionButton,
 .modalCloseButton,
 .themeToggleLabel {
     user-select: none;


### PR DESCRIPTION
### Description
This Pull Request introduces significant UI and UX improvements to the end-of-level flow and the Level Pack Selector. It refines keyboard accessibility, updates button styling for consistency, and integrates the pack selector directly into both the end-of-pack completion modal and the primary hamburger menu.

### Key Changes
* **End-of-Pack Navigation:** Added a "Level Packs" button directly to the completion popup, allowing users to seamlessly transition to a new pack when they finish their current one.
* **Hamburger Menu Integration:** Added a "Level Packs" trigger to the main hamburger menu, providing a secondary, consistent access point to the selector regardless of the current level state.
* **Keyboard Accessibility Enhancements:** 
  * Implemented robust arrow-key navigation within the `LevelSelectorModal` to cycle through available packs.
  * Added `Enter` and `Space` key event listeners to activate the currently focused pack or button.
  * Ensured `Escape` properly dismisses the level selector modal.
  * Updated the completion popup to support arrow-key focus switching between the "Continue" and "Level Packs" options.
* **Styling Unification:** Deprecated the bespoke `.completionButton` CSS class in favor of the standardized `.levelNavButton` class to ensure visual consistency across all modal interactions.