### PR TITLE
feat: add undo tracking to play statistics and UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ Click the [**Latest Release**](https://github.com/hubertbanas/sokoban/releases/l
 - The game UI can show play statistics via a single menu toggle.
 - `Menu -> Show Play Stats` is off by default to keep the HUD minimal.
 - When enabled, the HUD shows:
-	- `Current Run` with live move count and time spent on the current level.
-	- `Level Best` (best moves/time for the current level entry).
+	- A compact table with `Current Run` and `Level Best` rows.
+	- Columns for `Moves`, `Undos`, and `Time`.
 - Internally, the stats model stores both `levelId` and `puzzleId` records:
 	- `levelId` is used for player-facing per-level progress and bests.
 	- `puzzleId` is retained for forward compatibility in case future packs reuse the same puzzle layout across different levels.

--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -158,6 +158,7 @@ function mockSokoban(overrides: Partial<ReturnType<typeof useSokoban>> = {}) {
     level: buildLevel(),
     levelPacks: buildLevelPacks(),
     moveCount: 0,
+    undoCount: 0,
     elapsedTimeMs: 0,
     completionMetrics: null,
     state: State.playing,
@@ -592,6 +593,7 @@ test("restores play stats UI from persisted toggle state", () => {
   expect(screen.getByRole("region", { name: /play statistics/i })).toBeInTheDocument();
   expect(screen.getByText(/^Current$/)).toBeInTheDocument();
   expect(screen.getByText(/^Best$/)).toBeInTheDocument();
+  expect(screen.getByText(/^Undos$/)).toBeInTheDocument();
 });
 
 test("defaults play stats toggle to off for invalid persisted values", () => {
@@ -629,6 +631,7 @@ test("keeps completion dialog play stats hidden when toggle is off", () => {
   const completionDialog = screen.getByRole("dialog", { name: /level completed/i });
   expect(within(completionDialog).queryByText(/^Current$/)).not.toBeInTheDocument();
   expect(within(completionDialog).queryByText(/^Best$/)).not.toBeInTheDocument();
+  expect(within(completionDialog).queryByText(/^Undos$/)).not.toBeInTheDocument();
 });
 
 test("renders current and best placeholders when play stats toggle is enabled", () => {
@@ -644,8 +647,8 @@ test("renders current and best placeholders when play stats toggle is enabled", 
     throw new Error("Expected stats rows to be paragraph elements");
   }
 
-  expect(currentRun).toHaveAttribute("aria-label", "Current: Moves 0 Time 0:00");
-  expect(levelBest).toHaveAttribute("aria-label", "Best: Moves -- Time --:--");
+  expect(currentRun).toHaveAttribute("aria-label", "Current: Moves 0 Undos 0 Time 0:00");
+  expect(levelBest).toHaveAttribute("aria-label", "Best: Moves -- Undos -- Time --:--");
 });
 
 test("hides both play stats lines after disabling the toggle", () => {
@@ -655,16 +658,19 @@ test("hides both play stats lines after disabling the toggle", () => {
   setPlayStatsVisibility(true);
   expect(screen.getByText(/^Current$/)).toBeInTheDocument();
   expect(screen.getByText(/^Best$/)).toBeInTheDocument();
+  expect(screen.getByText(/^Undos$/)).toBeInTheDocument();
 
   setPlayStatsVisibility(false);
   expect(screen.queryByText(/^Current$/)).not.toBeInTheDocument();
   expect(screen.queryByText(/^Best$/)).not.toBeInTheDocument();
+  expect(screen.queryByText(/^Undos$/)).not.toBeInTheDocument();
 });
 
 test("renders realtime current run status from useSokoban", () => {
   mockSokoban({
     state: State.playing,
     moveCount: 12,
+    undoCount: 3,
     elapsedTimeMs: 74_500,
   });
 
@@ -676,7 +682,7 @@ test("renders realtime current run status from useSokoban", () => {
     throw new Error("Expected current run row to be a paragraph element");
   }
 
-  expect(currentRun).toHaveAttribute("aria-label", "Current: Moves 12 Time 1:14");
+  expect(currentRun).toHaveAttribute("aria-label", "Current: Moves 12 Undos 3 Time 1:14");
 });
 
 test("renders best row from useStats", () => {
@@ -696,6 +702,7 @@ test("renders best row from useStats", () => {
             lastCompletedAt: 1600,
             bestMovesInLevel: 9,
             bestTimeMsInLevel: 13_000,
+            bestUndosInLevel: 2,
           },
         },
         records: {
@@ -720,7 +727,7 @@ test("renders best row from useStats", () => {
     throw new Error("Expected best row to be a paragraph element");
   }
 
-  expect(levelBestLine).toHaveAttribute("aria-label", "Best: Moves 9 Time 0:13");
+  expect(levelBestLine).toHaveAttribute("aria-label", "Best: Moves 9 Undos 2 Time 0:13");
   expect(screen.queryByText(/^Puzzle Best:/)).not.toBeInTheDocument();
 });
 
@@ -741,6 +748,7 @@ test("shows best row inside completion dialog", () => {
             lastCompletedAt: 1700,
             bestMovesInLevel: 1,
             bestTimeMsInLevel: 2_000,
+            bestUndosInLevel: 4,
           },
         },
         records: {
@@ -771,8 +779,8 @@ test("shows best row inside completion dialog", () => {
     throw new Error("Expected completion stats rows to be paragraph elements");
   }
 
-  expect(currentRun).toHaveAttribute("aria-label", "Current: Moves 0 Time 0:00");
-  expect(levelBestLine).toHaveAttribute("aria-label", "Best: Moves 1 Time 0:02");
+  expect(currentRun).toHaveAttribute("aria-label", "Current: Moves 0 Undos 0 Time 0:00");
+  expect(levelBestLine).toHaveAttribute("aria-label", "Best: Moves 1 Undos 4 Time 0:02");
   expect(within(completionDialog).queryByText(/^Puzzle Best:/)).not.toBeInTheDocument();
 });
 
@@ -1555,6 +1563,7 @@ test("saves completion metrics when state changes to completed", () => {
   const completionMetrics = {
     moves: 12,
     timeMs: 3456,
+    undos: 2,
   };
 
   mockSokoban({ state: State.playing, level: completedLevel, completionMetrics: null });
@@ -1571,6 +1580,7 @@ test("saves completion metrics when state changes to completed", () => {
     puzzleId: completedLevel.puzzleId,
     moves: completionMetrics.moves,
     timeMs: completionMetrics.timeMs,
+    undos: completionMetrics.undos,
   });
 });
 
@@ -1587,6 +1597,7 @@ test("saves completion metrics only once per completion transition", () => {
   const completionMetrics = {
     moves: 7,
     timeMs: 1234,
+    undos: 1,
   };
 
   mockSokoban({ state: State.playing, level: completedLevel, completionMetrics: null });

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -40,31 +40,46 @@ type StatsTableProps = {
   rowClassName: string;
   currentMoves: number;
   currentTimeMs: number;
+  currentUndos: number;
   bestMoves: number | null;
   bestTimeMs: number | null;
+  bestUndos: number | null;
 };
 
-function StatsTable({ rowClassName, currentMoves, currentTimeMs, bestMoves, bestTimeMs }: StatsTableProps) {
+function StatsTable({
+  rowClassName,
+  currentMoves,
+  currentTimeMs,
+  currentUndos,
+  bestMoves,
+  bestTimeMs,
+  bestUndos,
+}: StatsTableProps) {
   const currentMoveValue = String(currentMoves);
   const currentTimeValue = formatElapsedTime(currentTimeMs);
+  const currentUndoValue = String(currentUndos);
   const bestMoveValue = bestMoves === null ? "--" : String(bestMoves);
   const bestTimeValue = bestTimeMs === null ? "--:--" : formatElapsedTime(bestTimeMs);
+  const bestUndoValue = bestUndos === null ? "--" : String(bestUndos);
 
   return (
     <>
       <p className={rowClassName} aria-hidden="true">
         <span className={style.statsHeaderCell}>Run</span>
         <span className={style.statsHeaderCell}>Moves</span>
+        <span className={style.statsHeaderCell}>Undos</span>
         <span className={style.statsHeaderCell}>Time</span>
       </p>
-      <p className={rowClassName} aria-label={`Current: Moves ${currentMoveValue} Time ${currentTimeValue}`}>
+      <p className={rowClassName} aria-label={`Current: Moves ${currentMoveValue} Undos ${currentUndoValue} Time ${currentTimeValue}`}>
         <span className={style.statsRunCell}>Current</span>
         <span className={style.statsValueCell}>{currentMoveValue}</span>
+        <span className={style.statsValueCell}>{currentUndoValue}</span>
         <span className={style.statsValueCell}>{currentTimeValue}</span>
       </p>
-      <p className={rowClassName} aria-label={`Best: Moves ${bestMoveValue} Time ${bestTimeValue}`}>
+      <p className={rowClassName} aria-label={`Best: Moves ${bestMoveValue} Undos ${bestUndoValue} Time ${bestTimeValue}`}>
         <span className={style.statsRunCell}>Best</span>
         <span className={style.statsValueCell}>{bestMoveValue}</span>
+        <span className={style.statsValueCell}>{bestUndoValue}</span>
         <span className={style.statsValueCell}>{bestTimeValue}</span>
       </p>
     </>
@@ -159,6 +174,7 @@ function Game() {
     level,
     levelPacks,
     moveCount,
+    undoCount,
     elapsedTimeMs,
     completionMetrics,
     state,
@@ -410,6 +426,7 @@ function Game() {
           puzzleId: level.puzzleId,
           moves: completionMetrics.moves,
           timeMs: completionMetrics.timeMs,
+          undos: completionMetrics.undos,
         });
       }
     }
@@ -546,6 +563,7 @@ function Game() {
     levelBest.bestTimeMsInLevel !== null;
   const levelBestMoves = hasLevelBestRecord ? levelBest.bestMovesInLevel : null;
   const levelBestTimeMs = hasLevelBestRecord ? levelBest.bestTimeMsInLevel : null;
+  const levelBestUndos = levelBest?.bestUndosInLevel ?? null;
 
   useKeyBoard(
     (event) => {
@@ -801,8 +819,10 @@ function Game() {
             rowClassName={style.bestStatsRow}
             currentMoves={moveCount}
             currentTimeMs={elapsedTimeMs}
+            currentUndos={undoCount}
             bestMoves={levelBestMoves}
             bestTimeMs={levelBestTimeMs}
+            bestUndos={levelBestUndos}
           />
         </section>
       )}
@@ -920,8 +940,10 @@ function Game() {
                   rowClassName={style.completionStatsRow}
                   currentMoves={moveCount}
                   currentTimeMs={elapsedTimeMs}
+                  currentUndos={undoCount}
                   bestMoves={levelBestMoves}
                   bestTimeMs={levelBestTimeMs}
+                  bestUndos={levelBestUndos}
                 />
               </div>
             )}

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -79,7 +79,7 @@
     color: inherit;
     padding: 0 0.25ch;
     display: grid;
-    grid-template-columns: 1fr 5ch 7ch;
+    grid-template-columns: 1fr 5ch 5ch 7ch;
     column-gap: 0.8ch;
     align-items: baseline;
     text-align: left;
@@ -108,7 +108,8 @@
 }
 
 .statsHeaderCell:nth-child(2),
-.statsHeaderCell:nth-child(3) {
+.statsHeaderCell:nth-child(3),
+.statsHeaderCell:nth-child(4) {
     text-align: right;
 }
 

--- a/src/hooks/sokoban.test.ts
+++ b/src/hooks/sokoban.test.ts
@@ -66,6 +66,7 @@ test("blocked movement updates player orientation without moving or adding progr
     expect(result.current.level.playerPosition).toEqual({ row: 1, column: 1 });
     expect(result.current.hasProgress).toBe(false);
     expect(result.current.moveCount).toBe(0);
+    expect(result.current.undoCount).toBe(0);
 
     let outcome: MoveOutcome = "step";
     act(() => {
@@ -112,6 +113,7 @@ test("tracks realtime play status for moves and elapsed time", () => {
     const { result } = renderHook(() => useSokoban());
 
     expect(result.current.moveCount).toBe(0);
+    expect(result.current.undoCount).toBe(0);
     expect(result.current.elapsedTimeMs).toBe(0);
 
     act(() => {
@@ -135,6 +137,7 @@ test("tracks realtime play status for moves and elapsed time", () => {
 
     expect(didUndo).toBe(true);
     expect(result.current.moveCount).toBe(0);
+    expect(result.current.undoCount).toBe(1);
 });
 
 test("captures completion metrics when level is solved", () => {
@@ -180,6 +183,7 @@ test("captures completion metrics when level is solved", () => {
     expect(result.current.completionMetrics).toEqual({
         moves: 1,
         timeMs: 3600,
+        undos: 0,
     });
 });
 
@@ -224,6 +228,7 @@ test("resets completion metrics after advancing from completed state", () => {
     expect(result.current.completionMetrics).toEqual({
         moves: 1,
         timeMs: 1500,
+        undos: 0,
     });
 
     act(() => {
@@ -233,5 +238,6 @@ test("resets completion metrics after advancing from completed state", () => {
     expect(loadNext).toHaveBeenCalledTimes(1);
     expect(result.current.state).toBe(State.playing);
     expect(result.current.elapsedTimeMs).toBe(0);
+    expect(result.current.undoCount).toBe(0);
     expect(result.current.completionMetrics).toBeNull();
 });

--- a/src/hooks/sokoban.ts
+++ b/src/hooks/sokoban.ts
@@ -19,6 +19,7 @@ export type MoveOutcome = "blocked" | "step" | "crate-push" | "crate-docked";
 export type CompletionMetrics = {
   moves: number;
   timeMs: number;
+  undos: number;
 };
 
 type Position = {
@@ -64,6 +65,7 @@ export function useSokoban() {
   const [state, setState] = useState<State>(State.playing);
   const [hasProgress, setHasProgress] = useState(false);
   const [moveCount, setMoveCount] = useState(0);
+  const [undoCount, setUndoCount] = useState(0);
   const [elapsedTimeMs, setElapsedTimeMs] = useState(0);
   const [completionMetrics, setCompletionMetrics] = useState<CompletionMetrics | null>(null);
   const levelStartedAtRef = useRef(Date.now());
@@ -81,6 +83,7 @@ export function useSokoban() {
 
   const resetLevelRuntime = useCallback(() => {
     setMoveCount(0);
+    setUndoCount(0);
     setElapsedTimeMs(0);
     setCompletionMetrics(null);
     levelStartedAtRef.current = Date.now();
@@ -150,6 +153,7 @@ export function useSokoban() {
           setCompletionMetrics({
             moves: nextMoveCount,
             timeMs: finalElapsedTimeMs,
+            undos: undoCount,
           });
         }
         if (!movingBlock) board.pop();
@@ -171,7 +175,7 @@ export function useSokoban() {
 
       return "blocked";
     },
-    [board, moveCount, state]
+    [board, moveCount, state, undoCount]
   );
 
   const next = useCallback(() => {
@@ -211,6 +215,7 @@ export function useSokoban() {
     if (state === State.playing && board.length > 1) {
       setBoard(board.slice(0, -1));
       setMoveCount((current) => Math.max(0, current - 1));
+      setUndoCount((current) => current + 1);
       return true;
     }
 
@@ -253,6 +258,7 @@ export function useSokoban() {
     levelPacks,
     totalLevels,
     moveCount,
+    undoCount,
     elapsedTimeMs,
     completionMetrics,
     state,

--- a/src/hooks/useStats.test.ts
+++ b/src/hooks/useStats.test.ts
@@ -41,6 +41,7 @@ test("loads and sanitizes partially invalid stored payload", () => {
                     isCompleted: true,
                     bestMovesInLevel: 120,
                     bestTimeMsInLevel: 9000,
+                    bestUndosInLevel: "bad",
                     lastPlayedAt: 100,
                     lastCompletedAt: 200,
                 },
@@ -67,6 +68,7 @@ test("loads and sanitizes partially invalid stored payload", () => {
         isCompleted: true,
         bestMovesInLevel: 120,
         bestTimeMsInLevel: 9000,
+        bestUndosInLevel: null,
     });
     expect(result.current.stats.records.abc12345).toBeUndefined();
 });
@@ -80,6 +82,7 @@ test("saveLevelResult creates progression and records and persists", () => {
             puzzleId: "deadbeef",
             moves: 57,
             timeMs: 12345,
+            undos: 4,
             completedAt: 1000,
         });
     });
@@ -90,6 +93,7 @@ test("saveLevelResult creates progression and records and persists", () => {
         isCompleted: true,
         bestMovesInLevel: 57,
         bestTimeMsInLevel: 12345,
+        bestUndosInLevel: 4,
         lastPlayedAt: 1000,
         lastCompletedAt: 1000,
     });
@@ -115,6 +119,7 @@ test("saveLevelResult keeps best metrics while counting plays", () => {
             puzzleId: "deadbeef",
             moves: 35,
             timeMs: 9000,
+            undos: 5,
             completedAt: 1000,
         });
     });
@@ -125,6 +130,7 @@ test("saveLevelResult keeps best metrics while counting plays", () => {
             puzzleId: "deadbeef",
             moves: 42,
             timeMs: 8500,
+            undos: 6,
             completedAt: 2000,
         });
     });
@@ -134,6 +140,7 @@ test("saveLevelResult keeps best metrics while counting plays", () => {
         completionCount: 2,
         bestMovesInLevel: 35,
         bestTimeMsInLevel: 8500,
+        bestUndosInLevel: 5,
         lastCompletedAt: 2000,
     });
     expect(result.current.stats.records.deadbeef).toMatchObject({

--- a/src/hooks/useStats.ts
+++ b/src/hooks/useStats.ts
@@ -11,6 +11,7 @@ export type LevelProgress = {
     lastCompletedAt: number | null;
     bestMovesInLevel: number | null;
     bestTimeMsInLevel: number | null;
+    bestUndosInLevel: number | null;
 };
 
 export type PuzzleRecord = {
@@ -33,6 +34,7 @@ export type SaveLevelResultInput = {
     puzzleId: string;
     moves: number;
     timeMs: number;
+    undos?: number;
     completedAt?: number;
 };
 
@@ -74,6 +76,7 @@ function createEmptyLevelProgress(): LevelProgress {
         lastCompletedAt: null,
         bestMovesInLevel: null,
         bestTimeMsInLevel: null,
+        bestUndosInLevel: null,
     };
 }
 
@@ -103,6 +106,7 @@ function sanitizeLevelProgress(value: unknown): LevelProgress {
         lastCompletedAt: toTimestamp(value.lastCompletedAt),
         bestMovesInLevel: toBestMetric(value.bestMovesInLevel),
         bestTimeMsInLevel: toBestMetric(value.bestTimeMsInLevel),
+        bestUndosInLevel: toBestMetric(value.bestUndosInLevel),
     };
 }
 
@@ -220,6 +224,7 @@ export function useStats() {
         const completedAt = toTimestamp(input.completedAt) ?? Date.now();
         const moves = toNonNegativeInteger(input.moves);
         const timeMs = toNonNegativeInteger(input.timeMs);
+        const undos = input.undos === undefined ? null : toNonNegativeInteger(input.undos);
 
         setStats((current) => {
             const currentProgress = current.progression[input.levelId] ?? createEmptyLevelProgress();
@@ -231,6 +236,10 @@ export function useStats() {
                 lastCompletedAt: completedAt,
                 bestMovesInLevel: nextBest(currentProgress.bestMovesInLevel, moves),
                 bestTimeMsInLevel: nextBest(currentProgress.bestTimeMsInLevel, timeMs),
+                bestUndosInLevel:
+                    undos === null
+                        ? currentProgress.bestUndosInLevel
+                        : nextBest(currentProgress.bestUndosInLevel, undos),
             };
 
             const currentRecord = current.records[input.puzzleId];


### PR DESCRIPTION
### Description
This Pull Request expands the in-game statistics system by introducing tracking for player undos. It updates the core game state to record undo actions and surfaces this metric in the persistent UI, allowing players to evaluate their current run's undo count alongside their all-time best performance for a specific puzzle layout.

### Key Changes
* **State Management:** Implemented tracking for undo counts directly within the core game state and performance metrics.
* **UI Integration:** Updated the play statistics display to actively render both the current run's undo count and the historical best undo count.
* **Styling Enhancements:** Adjusted the CSS for the stats table layout to cleanly accommodate the new dedicated column for undos.
* **Test Coverage:** Enhanced the test suite to verify the accurate tracking of undo actions and their proper integration into the end-of-level completion metrics.