### PR TITLE
style: refine menu appearance and navigation button UI

### DIFF
--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -446,7 +446,7 @@
     gap: 14px;
     background: var(--surface);
     border-right: 1px solid var(--border);
-    box-shadow: 18px 0 42px rgba(0, 0, 0, 0.24);
+    box-shadow: none;
     transform: translateX(-100%);
     transition: transform 0.26s cubic-bezier(0.25, 0.8, 0.25, 1);
     will-change: transform;

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -525,6 +525,9 @@
 }
 
 .menuResetStatsButton {
+    display: flex;
+    align-items: center;
+    justify-content: center;
     text-align: center;
 }
 

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -419,6 +419,13 @@
     flex-wrap: wrap;
 }
 
+.completionOverlay .levelNavButton:focus,
+.completionOverlay .levelNavButton:focus-visible {
+    outline: none;
+    box-shadow: none;
+    border-color: var(--accent);
+}
+
 .menuBackdrop {
     position: fixed;
     inset: 0;
@@ -826,6 +833,13 @@
 
 .levelSelectorPackPlayButton {
     align-self: center;
+}
+
+.levelSelectorPackPlayButton:focus,
+.levelSelectorPackPlayButton:focus-visible {
+    outline: none;
+    box-shadow: none;
+    border-color: var(--accent);
 }
 
 .levelSelectorPackDescription {


### PR DESCRIPTION
### Description
This Pull Request focuses on visual polish and UI refinements across the application. It removes unnecessary visual elements to create a cleaner aesthetic and completes the styling for the newly introduced "Reset Stats" button within the navigation menu.

### Key Changes
* **Navigation Buttons:** Removed default focus outlines and box shadows from the level navigation buttons to provide a cleaner interface during gameplay.
* **Menu Drawer:** Removed the box shadow from the hamburger menu drawer for a flatter, more seamless appearance.
* **Reset Stats Button:** Applied dedicated styling to the "Reset Stats" button to ensure it aligns with the design language of the navigation menu.