### PR TITLE
feat: complete multilingual i18n support and UI refinements

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,9 +34,12 @@
   ],
   "dependencies": {
     "@capacitor/core": "^8.2.0",
+    "i18next": "^26.1.0",
+    "i18next-browser-languagedetector": "^8.2.1",
     "lodash": "4.18.1",
     "react": "19",
-    "react-dom": "19"
+    "react-dom": "19",
+    "react-i18next": "^17.0.7"
   },
   "devDependencies": {
     "@capacitor/android": "^8.2.0",

--- a/src/Game.test.tsx
+++ b/src/Game.test.tsx
@@ -628,11 +628,11 @@ test("renders current and best placeholders when play stats toggle is enabled", 
   render(<Game />);
   setPlayStatsVisibility(true);
 
-  const currentRun = screen.getByText(/^Current$/).closest("p");
-  const levelBest = screen.getByText(/^Best$/).closest("p");
+  const currentRun = screen.getByText(/^Current$/).closest("tr");
+  const levelBest = screen.getByText(/^Best$/).closest("tr");
 
   if (!currentRun || !levelBest) {
-    throw new Error("Expected stats rows to be paragraph elements");
+    throw new Error("Expected stats rows to be table rows");
   }
 
   expect(currentRun).toHaveAttribute("aria-label", "Current: Moves 0 Undos 0 Time 0:00");
@@ -665,9 +665,9 @@ test("renders realtime current run status from useSokoban", () => {
   render(<Game />);
   setPlayStatsVisibility(true);
 
-  const currentRun = screen.getByText(/^Current$/).closest("p");
+  const currentRun = screen.getByText(/^Current$/).closest("tr");
   if (!currentRun) {
-    throw new Error("Expected current run row to be a paragraph element");
+    throw new Error("Expected current run row to be a table row");
   }
 
   expect(currentRun).toHaveAttribute("aria-label", "Current: Moves 12 Undos 3 Time 1:14");
@@ -710,9 +710,9 @@ test("renders best row from useStats", () => {
   render(<Game />);
   setPlayStatsVisibility(true);
 
-  const levelBestLine = screen.getByText(/^Best$/).closest("p");
+  const levelBestLine = screen.getByText(/^Best$/).closest("tr");
   if (!levelBestLine) {
-    throw new Error("Expected best row to be a paragraph element");
+    throw new Error("Expected best row to be a table row");
   }
 
   expect(levelBestLine).toHaveAttribute("aria-label", "Best: Moves 9 Undos 2 Time 0:13");
@@ -760,11 +760,11 @@ test("shows best row inside completion dialog", () => {
   rerender(<Game />);
 
   const completionDialog = screen.getByRole("dialog", { name: /level completed/i });
-  const currentRun = within(completionDialog).getByText(/^Current$/).closest("p");
-  const levelBestLine = within(completionDialog).getByText(/^Best$/).closest("p");
+  const currentRun = within(completionDialog).getByText(/^Current$/).closest("tr");
+  const levelBestLine = within(completionDialog).getByText(/^Best$/).closest("tr");
 
   if (!currentRun || !levelBestLine) {
-    throw new Error("Expected completion stats rows to be paragraph elements");
+    throw new Error("Expected completion stats rows to be table rows");
   }
 
   expect(currentRun).toHaveAttribute("aria-label", "Current: Moves 0 Undos 0 Time 0:00");

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { Trans, useTranslation } from "react-i18next";
 import "./Game.css";
 import { Help } from "./components/help";
 import { HamburgerMenu } from "./components/hamburger-menu";
@@ -54,6 +55,7 @@ function StatsTable({
   bestTimeMs,
   bestUndos,
 }: StatsTableProps) {
+  const { t } = useTranslation();
   const currentMoveValue = String(currentMoves);
   const currentTimeValue = formatElapsedTime(currentTimeMs);
   const currentUndoValue = String(currentUndos);
@@ -64,19 +66,33 @@ function StatsTable({
   return (
     <>
       <p className={rowClassName} aria-hidden="true">
-        <span className={style.statsHeaderCell}>Run</span>
-        <span className={style.statsHeaderCell}>Moves</span>
-        <span className={style.statsHeaderCell}>Undos</span>
-        <span className={style.statsHeaderCell}>Time</span>
+        <span className={style.statsHeaderCell}>{t("game.stats.header.run")}</span>
+        <span className={style.statsHeaderCell}>{t("game.stats.header.moves")}</span>
+        <span className={style.statsHeaderCell}>{t("game.stats.header.undos")}</span>
+        <span className={style.statsHeaderCell}>{t("game.stats.header.time")}</span>
       </p>
-      <p className={rowClassName} aria-label={`Current: Moves ${currentMoveValue} Undos ${currentUndoValue} Time ${currentTimeValue}`}>
-        <span className={style.statsRunCell}>Current</span>
+      <p
+        className={rowClassName}
+        aria-label={t("game.stats.aria.current", {
+          moves: currentMoveValue,
+          undos: currentUndoValue,
+          time: currentTimeValue,
+        })}
+      >
+        <span className={style.statsRunCell}>{t("game.stats.run.current")}</span>
         <span className={style.statsValueCell}>{currentMoveValue}</span>
         <span className={style.statsValueCell}>{currentUndoValue}</span>
         <span className={style.statsValueCell}>{currentTimeValue}</span>
       </p>
-      <p className={rowClassName} aria-label={`Best: Moves ${bestMoveValue} Undos ${bestUndoValue} Time ${bestTimeValue}`}>
-        <span className={style.statsRunCell}>Best</span>
+      <p
+        className={rowClassName}
+        aria-label={t("game.stats.aria.best", {
+          moves: bestMoveValue,
+          undos: bestUndoValue,
+          time: bestTimeValue,
+        })}
+      >
+        <span className={style.statsRunCell}>{t("game.stats.run.best")}</span>
         <span className={style.statsValueCell}>{bestMoveValue}</span>
         <span className={style.statsValueCell}>{bestUndoValue}</span>
         <span className={style.statsValueCell}>{bestTimeValue}</span>
@@ -168,6 +184,7 @@ function useHoldToRepeat(
 }
 
 function Game() {
+  const { t } = useTranslation();
   const {
     index,
     level,
@@ -440,43 +457,43 @@ function Game() {
     switch (pendingAction?.type) {
       case "restart":
         return {
-          title: "Restart level?",
-          ariaLabel: "Restart level confirmation",
-          warningText: "Restarting now will erase your progress on this level.",
-          confirmLabel: "Restart Level",
+          title: t("game.confirmation.restart.title"),
+          ariaLabel: t("game.confirmation.restart.ariaLabel"),
+          warningText: t("game.confirmation.restart.warning"),
+          confirmLabel: t("game.confirmation.restart.confirm"),
         };
       case "previous":
         return {
-          title: "Switch level?",
-          ariaLabel: "Switch to previous level confirmation",
-          warningText: "Switching levels now will erase your progress on this level.",
-          confirmLabel: "Go to Previous Level",
+          title: t("game.confirmation.switch.title"),
+          ariaLabel: t("game.confirmation.switch.previousAriaLabel"),
+          warningText: t("game.confirmation.switch.warning"),
+          confirmLabel: t("game.confirmation.switch.previousConfirm"),
         };
       case "next":
         return {
-          title: "Switch level?",
-          ariaLabel: "Switch to next level confirmation",
-          warningText: "Switching levels now will erase your progress on this level.",
-          confirmLabel: "Go to Next Level",
+          title: t("game.confirmation.switch.title"),
+          ariaLabel: t("game.confirmation.switch.nextAriaLabel"),
+          warningText: t("game.confirmation.switch.warning"),
+          confirmLabel: t("game.confirmation.switch.nextConfirm"),
         };
       case "select-level":
         return {
-          title: "Switch level?",
-          ariaLabel: "Switch to selected level confirmation",
-          warningText: "Switching levels now will erase your progress on this level.",
-          confirmLabel: "Go to Selected Level",
+          title: t("game.confirmation.switch.title"),
+          ariaLabel: t("game.confirmation.switch.selectedAriaLabel"),
+          warningText: t("game.confirmation.switch.warning"),
+          confirmLabel: t("game.confirmation.switch.selectedConfirm"),
         };
       case "reset-stats":
         return {
-          title: "Reset stats?",
-          ariaLabel: "Reset stats confirmation",
-          warningText: "Resetting stats will permanently remove your saved moves, undos, and times.",
-          confirmLabel: "Reset Stats",
+          title: t("game.confirmation.resetStats.title"),
+          ariaLabel: t("game.confirmation.resetStats.ariaLabel"),
+          warningText: t("game.confirmation.resetStats.warning"),
+          confirmLabel: t("game.confirmation.resetStats.confirm"),
         };
       default:
         return null;
     }
-  }, [pendingAction]);
+  }, [pendingAction, t]);
 
   React.useEffect(() => {
     const viewport = boardViewportRef.current;
@@ -556,7 +573,7 @@ function Game() {
 
     return currentPackLevelIndex === currentPack.levels.length - 1;
   }, [currentPack, currentPackLevelIndex]);
-  const levelPickerPackName = currentPack?.title ?? "Levels";
+  const levelPickerPackName = currentPack?.title ?? t("game.levelPicker.fallbackPackName");
   const levelPickerNumbers = React.useMemo(() => {
     if (!currentPack || currentPack.levels.length === 0) {
       return `${index + 1} / ${levelCount}`;
@@ -771,7 +788,7 @@ function Game() {
           <button
             type="button"
             className={style.menuToggleButton}
-            aria-label={isMenuOpen ? "Close menu" : "Open menu"}
+            aria-label={isMenuOpen ? t("game.menu.close") : t("game.menu.open")}
             aria-controls="game-menu"
             aria-expanded={isMenuOpen}
             onClick={onToggleMenu}
@@ -785,12 +802,12 @@ function Game() {
         </div>
 
         <div className={style.levelInfo}>
-          <div className={style.levelPicker} aria-label="Level picker">
+          <div className={style.levelPicker} aria-label={t("game.levelPicker.label")}>
             <button
               type="button"
               className={`${style.levelNavButton} ${style.levelPickerButton}`}
-              aria-label="Previous Level"
-              title="Previous Level"
+              aria-label={t("game.levelPicker.previous")}
+              title={t("game.levelPicker.previous")}
               {...previousButtonHandlers}
             >
               <span className={style.levelPickerChevron} aria-hidden="true">&lsaquo;</span>
@@ -799,8 +816,8 @@ function Game() {
             <button
               type="button"
               className={style.levelPickerLevelButton}
-              aria-label="Open level selector"
-              title="Open level selector"
+              aria-label={t("game.levelPicker.openSelector")}
+              title={t("game.levelPicker.openSelector")}
               onClick={onOpenLevelSelector}
             >
               <span className={style.levelPickerPackName}>{levelPickerPackName}</span>
@@ -810,8 +827,8 @@ function Game() {
             <button
               type="button"
               className={`${style.levelNavButton} ${style.levelPickerButton}`}
-              aria-label="Next Level"
-              title="Next Level"
+              aria-label={t("game.levelPicker.next")}
+              title={t("game.levelPicker.next")}
               {...nextButtonHandlers}
             >
               <span className={style.levelPickerChevron} aria-hidden="true">&rsaquo;</span>
@@ -823,7 +840,7 @@ function Game() {
       </header>
 
       {showPlayStats && (
-        <section className={style.bestStatsBar} aria-label="Play statistics">
+        <section className={style.bestStatsBar} aria-label={t("game.playStats.regionLabel")}>
           <StatsTable
             rowClassName={style.bestStatsRow}
             currentMoves={moveCount}
@@ -836,7 +853,7 @@ function Game() {
         </section>
       )}
 
-      <section className={style.mapArea} aria-label="Sokoban board">
+      <section className={style.mapArea} aria-label={t("game.board.label")}>
         <div className={style.boardViewport} ref={boardViewportRef}>
           <div className={style.board} style={boardVars}>
             {level.shape.map((row, rowIndex) => (
@@ -905,7 +922,7 @@ function Game() {
               autoFocus
               ref={cancelButtonRef}
             >
-              Cancel
+              {t("common.cancel")}
             </button>
             <button
               type="button"
@@ -921,24 +938,36 @@ function Game() {
       )}
 
       {state === State.completed && !isLevelSelectorOpen && (
-        <div className={style.completionOverlay} role="dialog" aria-modal="true" aria-label="Level completed">
+        <div
+          className={style.completionOverlay}
+          role="dialog"
+          aria-modal="true"
+          aria-label={t("game.completion.ariaLabel")}
+        >
           <div className={style.completionCard}>
             <h2 className={style.completionTitle}>
-              {isLastLevelInCurrentPack ? "Level Pack Complete!" : "Congratulations!"}
+              {isLastLevelInCurrentPack
+                ? t("game.completion.title.packComplete")
+                : t("game.completion.title.congratulations")}
             </h2>
             <p className={style.completionText}>
               {isLastLevelInCurrentPack
-                ? "You completed the last level in this pack."
-                : "You completed this level."}
+                ? t("game.completion.message.packComplete")
+                : t("game.completion.message.levelComplete")}
             </p>
             {isLastLevelInCurrentPack && (
               <p className={style.completionText}>
-                Switch to a different level pack from the <span className={style.completionTextAccent}>Level Packs</span>
-                {" "}selector, or press <span className={style.completionTextAccent}>Continue</span> to return to Level 1 in this pack.
+                <Trans
+                  i18nKey="game.completion.message.packSwitch"
+                  components={{
+                    levelPacks: <span className={style.completionTextAccent} />,
+                    continue: <span className={style.completionTextAccent} />,
+                  }}
+                />
               </p>
             )}
             {showPlayStats && (
-              <div className={style.completionStats} aria-label="Run and best records">
+              <div className={style.completionStats} aria-label={t("game.playStats.runAndBestLabel")}>
                 <StatsTable
                   rowClassName={style.completionStatsRow}
                   currentMoves={moveCount}
@@ -959,10 +988,10 @@ function Game() {
                   autoFocus
                   ref={completionLevelPacksButtonRef}
                 >
-                  Level Packs
+                  {t("common.levelPacks")}
                 </button>
                 <button type="button" className={style.levelNavButton} onClick={next} ref={completionContinueButtonRef}>
-                  Continue
+                  {t("common.continue")}
                 </button>
               </div>
             ) : (
@@ -973,7 +1002,7 @@ function Game() {
                 ref={completionContinueButtonRef}
                 autoFocus
               >
-                Continue
+                {t("common.continue")}
               </button>
             )}
           </div>

--- a/src/Game.tsx
+++ b/src/Game.tsx
@@ -37,7 +37,7 @@ function getInitialPlayStatsVisibility(): boolean {
 }
 
 type StatsTableProps = {
-  rowClassName: string;
+  tableClassName: string;
   currentMoves: number;
   currentTimeMs: number;
   currentUndos: number;
@@ -47,7 +47,7 @@ type StatsTableProps = {
 };
 
 function StatsTable({
-  rowClassName,
+  tableClassName,
   currentMoves,
   currentTimeMs,
   currentUndos,
@@ -64,40 +64,42 @@ function StatsTable({
   const bestUndoValue = bestUndos === null ? "--" : String(bestUndos);
 
   return (
-    <>
-      <p className={rowClassName} aria-hidden="true">
-        <span className={style.statsHeaderCell}>{t("game.stats.header.run")}</span>
-        <span className={style.statsHeaderCell}>{t("game.stats.header.moves")}</span>
-        <span className={style.statsHeaderCell}>{t("game.stats.header.undos")}</span>
-        <span className={style.statsHeaderCell}>{t("game.stats.header.time")}</span>
-      </p>
-      <p
-        className={rowClassName}
-        aria-label={t("game.stats.aria.current", {
-          moves: currentMoveValue,
-          undos: currentUndoValue,
-          time: currentTimeValue,
-        })}
-      >
-        <span className={style.statsRunCell}>{t("game.stats.run.current")}</span>
-        <span className={style.statsValueCell}>{currentMoveValue}</span>
-        <span className={style.statsValueCell}>{currentUndoValue}</span>
-        <span className={style.statsValueCell}>{currentTimeValue}</span>
-      </p>
-      <p
-        className={rowClassName}
-        aria-label={t("game.stats.aria.best", {
-          moves: bestMoveValue,
-          undos: bestUndoValue,
-          time: bestTimeValue,
-        })}
-      >
-        <span className={style.statsRunCell}>{t("game.stats.run.best")}</span>
-        <span className={style.statsValueCell}>{bestMoveValue}</span>
-        <span className={style.statsValueCell}>{bestUndoValue}</span>
-        <span className={style.statsValueCell}>{bestTimeValue}</span>
-      </p>
-    </>
+    <table className={`${style.statsTable} ${tableClassName}`}>
+      <thead>
+        <tr>
+          <th className={style.statsHeaderCell} scope="col">{t("game.stats.header.run")}</th>
+          <th className={style.statsHeaderCell} scope="col">{t("game.stats.header.moves")}</th>
+          <th className={style.statsHeaderCell} scope="col">{t("game.stats.header.undos")}</th>
+          <th className={style.statsHeaderCell} scope="col">{t("game.stats.header.time")}</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          aria-label={t("game.stats.aria.current", {
+            moves: currentMoveValue,
+            undos: currentUndoValue,
+            time: currentTimeValue,
+          })}
+        >
+          <th className={style.statsRunCell} scope="row">{t("game.stats.run.current")}</th>
+          <td className={style.statsValueCell}>{currentMoveValue}</td>
+          <td className={style.statsValueCell}>{currentUndoValue}</td>
+          <td className={style.statsValueCell}>{currentTimeValue}</td>
+        </tr>
+        <tr
+          aria-label={t("game.stats.aria.best", {
+            moves: bestMoveValue,
+            undos: bestUndoValue,
+            time: bestTimeValue,
+          })}
+        >
+          <th className={style.statsRunCell} scope="row">{t("game.stats.run.best")}</th>
+          <td className={style.statsValueCell}>{bestMoveValue}</td>
+          <td className={style.statsValueCell}>{bestUndoValue}</td>
+          <td className={style.statsValueCell}>{bestTimeValue}</td>
+        </tr>
+      </tbody>
+    </table>
   );
 }
 
@@ -842,7 +844,7 @@ function Game() {
       {showPlayStats && (
         <section className={style.bestStatsBar} aria-label={t("game.playStats.regionLabel")}>
           <StatsTable
-            rowClassName={style.bestStatsRow}
+            tableClassName={style.bestStatsRow}
             currentMoves={moveCount}
             currentTimeMs={elapsedTimeMs}
             currentUndos={undoCount}
@@ -969,7 +971,7 @@ function Game() {
             {showPlayStats && (
               <div className={style.completionStats} aria-label={t("game.playStats.runAndBestLabel")}>
                 <StatsTable
-                  rowClassName={style.completionStatsRow}
+                  tableClassName={style.completionStatsRow}
                   currentMoves={moveCount}
                   currentTimeMs={elapsedTimeMs}
                   currentUndos={undoCount}

--- a/src/components/hamburger-menu.tsx
+++ b/src/components/hamburger-menu.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import style from "./sokoban.module.css";
 import { ThemeSwitcher } from "./theme-switcher";
 
@@ -29,6 +30,7 @@ function HamburgerMenuImpl({
     onOpenLevelSelector,
     onOpenAbout,
 }: HamburgerMenuProps) {
+    const { t, i18n } = useTranslation();
     const [isStatsExpanded, setIsStatsExpanded] = React.useState(false);
     const [isSfxExpanded, setIsSfxExpanded] = React.useState(false);
     const statsControlsId = React.useId();
@@ -37,7 +39,9 @@ function HamburgerMenuImpl({
     const sfxToggleId = React.useId();
     const sfxSliderId = React.useId();
     const volumePercent = Math.round(volume * 100);
-    const playStatsToggleLabel = showPlayStats ? "Disable play stats" : "Enable play stats";
+    const playStatsToggleLabel = showPlayStats ? t("menu.playStats.disable") : t("menu.playStats.enable");
+    const currentLanguage = (i18n.resolvedLanguage ?? i18n.language ?? "en").toLowerCase();
+    const selectedLanguage = currentLanguage.startsWith("en-xa") ? "en-xa" : "en";
 
     React.useEffect(() => {
         if (!open) {
@@ -58,17 +62,17 @@ function HamburgerMenuImpl({
                 id="game-menu"
                 role="dialog"
                 aria-modal="true"
-                aria-label="Game menu"
+                aria-label={t("menu.ariaLabel")}
                 aria-hidden={!open}
                 className={`${style.menuDrawer} ${open ? style.menuDrawerOpen : ""}`}
             >
                 <div className={style.menuDrawerHeader}>
-                    <h2 className={style.menuDrawerTitle}>Menu</h2>
+                    <h2 className={style.menuDrawerTitle}>{t("menu.title")}</h2>
                     <button
                         type="button"
                         className={style.menuDrawerCloseButton}
                         onClick={onClose}
-                        aria-label="Close menu"
+                        aria-label={t("game.menu.close")}
                     >
                         X
                     </button>
@@ -76,8 +80,23 @@ function HamburgerMenuImpl({
 
                 <div className={style.menuSection}>
                     <div className={style.menuThemeRow}>
-                        <span className={style.menuThemeLabel}>Theme</span>
+                        <span className={style.menuThemeLabel}>{t("menu.theme")}</span>
                         <ThemeSwitcher />
+                    </div>
+
+                    <div className={style.menuThemeRow}>
+                        <span className={style.menuThemeLabel}>{t("menu.language.label")}</span>
+                        <select
+                            className={style.menuLanguageSelect}
+                            value={selectedLanguage}
+                            onChange={(event) => {
+                                void i18n.changeLanguage(event.target.value);
+                            }}
+                            aria-label={t("menu.language.label")}
+                        >
+                            <option value="en">{t("menu.language.options.en")}</option>
+                            <option value="en-xa">{t("menu.language.options.en-xa")}</option>
+                        </select>
                     </div>
 
                     <div className={style.menuSfxItem}>
@@ -88,9 +107,9 @@ function HamburgerMenuImpl({
                             aria-expanded={isStatsExpanded}
                             aria-controls={statsControlsId}
                         >
-                            <span>Play Stats</span>
+                            <span>{t("menu.playStats.title")}</span>
                             <span className={style.menuSfxToggleState} aria-hidden="true">
-                                {isStatsExpanded ? "Hide" : "Show"}
+                                {isStatsExpanded ? t("common.hide") : t("common.show")}
                             </span>
                         </button>
 
@@ -100,7 +119,7 @@ function HamburgerMenuImpl({
                             aria-hidden={!isStatsExpanded}
                         >
                             <div className={style.menuSfxRow}>
-                                <span className={style.menuSfxRowLabel}>Visible</span>
+                                <span className={style.menuSfxRowLabel}>{t("menu.playStats.visible")}</span>
                                 <div className={style.themeSliderRow}>
                                     <input
                                         id={statsToggleId}
@@ -111,8 +130,8 @@ function HamburgerMenuImpl({
                                         aria-label={playStatsToggleLabel}
                                     />
                                     <label htmlFor={statsToggleId} className={style.themeToggleLabel}>
-                                        <span className={style.levelBestToggleOff} aria-hidden="true">Off</span>
-                                        <span className={style.levelBestToggleOn} aria-hidden="true">On</span>
+                                        <span className={style.levelBestToggleOff} aria-hidden="true">{t("common.off")}</span>
+                                        <span className={style.levelBestToggleOn} aria-hidden="true">{t("common.on")}</span>
                                         <span className={style.themeToggleBall} />
                                     </label>
                                 </div>
@@ -123,7 +142,7 @@ function HamburgerMenuImpl({
                                 className={`${style.menuItemButton} ${style.menuResetStatsButton}`}
                                 onClick={onResetStats}
                             >
-                                Reset Stats
+                                {t("menu.playStats.reset")}
                             </button>
                         </div>
                     </div>
@@ -136,9 +155,9 @@ function HamburgerMenuImpl({
                             aria-expanded={isSfxExpanded}
                             aria-controls={sfxControlsId}
                         >
-                            <span>SFX Settings</span>
+                            <span>{t("menu.sfx.title")}</span>
                             <span className={style.menuSfxToggleState} aria-hidden="true">
-                                {isSfxExpanded ? "Hide" : "Show"}
+                                {isSfxExpanded ? t("common.hide") : t("common.show")}
                             </span>
                         </button>
 
@@ -148,7 +167,7 @@ function HamburgerMenuImpl({
                             aria-hidden={!isSfxExpanded}
                         >
                             <div className={style.menuSfxRow}>
-                                <span className={style.menuSfxRowLabel}>Mute SFX</span>
+                                <span className={style.menuSfxRowLabel}>{t("menu.sfx.mute")}</span>
                                 <div className={style.themeSliderRow}>
                                     <input
                                         id={sfxToggleId}
@@ -156,18 +175,18 @@ function HamburgerMenuImpl({
                                         type="checkbox"
                                         checked={muted}
                                         onChange={(event) => onMutedChange(event.target.checked)}
-                                        aria-label="Mute SFX"
+                                        aria-label={t("menu.sfx.mute")}
                                     />
                                     <label htmlFor={sfxToggleId} className={style.themeToggleLabel}>
-                                        <span className={style.levelBestToggleOff} aria-hidden="true">Off</span>
-                                        <span className={style.levelBestToggleOn} aria-hidden="true">On</span>
+                                        <span className={style.levelBestToggleOff} aria-hidden="true">{t("common.off")}</span>
+                                        <span className={style.levelBestToggleOn} aria-hidden="true">{t("common.on")}</span>
                                         <span className={style.themeToggleBall} />
                                     </label>
                                 </div>
                             </div>
 
                             <div className={style.menuSfxRow}>
-                                <span className={style.menuSfxRowLabel}>Volume</span>
+                                <span className={style.menuSfxRowLabel}>{t("menu.sfx.volume")}</span>
                                 <label htmlFor={sfxSliderId} className={style.menuSfxVolumeLabel}>
                                     {volumePercent}%
                                 </label>
@@ -181,7 +200,7 @@ function HamburgerMenuImpl({
                                 max={100}
                                 step={5}
                                 value={volumePercent}
-                                aria-label="SFX volume"
+                                aria-label={t("menu.sfx.volumeAria")}
                                 onChange={(event) => onVolumeChange(Number(event.target.value) / 100)}
                                 disabled={muted}
                             />
@@ -189,15 +208,15 @@ function HamburgerMenuImpl({
                     </div>
 
                     <button type="button" className={style.menuItemButton} onClick={onOpenLevelSelector}>
-                        Level Packs
+                        {t("common.levelPacks")}
                     </button>
 
                     <button type="button" className={style.menuItemButton} onClick={onOpenAbout}>
-                        About
+                        {t("common.about")}
                     </button>
                 </div>
 
-                <div className={style.menuVersion}>Version {__APP_VERSION__}</div>
+                <div className={style.menuVersion}>{t("common.version", { version: __APP_VERSION__ })}</div>
             </aside>
         </>
     );

--- a/src/components/hamburger-menu.tsx
+++ b/src/components/hamburger-menu.tsx
@@ -22,6 +22,35 @@ type HamburgerMenuProps = {
     onOpenAbout: () => void;
 };
 
+function ToggleOffSymbol() {
+    return (
+        <svg className={style.togglePowerSymbol} viewBox="0 0 24 24" aria-hidden="true">
+            <circle cx="12" cy="12" r="6.5" fill="none" stroke="currentColor" strokeWidth="2.2" />
+        </svg>
+    );
+}
+
+function ToggleOnSymbol() {
+    return (
+        <svg className={style.togglePowerSymbol} viewBox="0 0 24 24" aria-hidden="true">
+            <path
+                d="M12 4.2v6.2"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.2"
+                strokeLinecap="round"
+            />
+            <path
+                d="M8.2 7.8a6.8 6.8 0 1 0 7.6 0"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.2"
+                strokeLinecap="round"
+            />
+        </svg>
+    );
+}
+
 function HamburgerMenuImpl({
     open,
     showPlayStats,
@@ -148,8 +177,12 @@ function HamburgerMenuImpl({
                                         aria-label={playStatsToggleLabel}
                                     />
                                     <label htmlFor={statsToggleId} className={style.themeToggleLabel}>
-                                        <span className={style.levelBestToggleOff} aria-hidden="true">{t("common.off")}</span>
-                                        <span className={style.levelBestToggleOn} aria-hidden="true">{t("common.on")}</span>
+                                        <span className={style.levelBestToggleOff} aria-hidden="true">
+                                            <ToggleOffSymbol />
+                                        </span>
+                                        <span className={style.levelBestToggleOn} aria-hidden="true">
+                                            <ToggleOnSymbol />
+                                        </span>
                                         <span className={style.themeToggleBall} />
                                     </label>
                                 </div>
@@ -196,8 +229,12 @@ function HamburgerMenuImpl({
                                         aria-label={t("menu.sfx.mute")}
                                     />
                                     <label htmlFor={sfxToggleId} className={style.themeToggleLabel}>
-                                        <span className={style.levelBestToggleOff} aria-hidden="true">{t("common.off")}</span>
-                                        <span className={style.levelBestToggleOn} aria-hidden="true">{t("common.on")}</span>
+                                        <span className={style.levelBestToggleOff} aria-hidden="true">
+                                            <ToggleOffSymbol />
+                                        </span>
+                                        <span className={style.levelBestToggleOn} aria-hidden="true">
+                                            <ToggleOnSymbol />
+                                        </span>
                                         <span className={style.themeToggleBall} />
                                     </label>
                                 </div>

--- a/src/components/hamburger-menu.tsx
+++ b/src/components/hamburger-menu.tsx
@@ -40,8 +40,19 @@ function HamburgerMenuImpl({
     const sfxSliderId = React.useId();
     const volumePercent = Math.round(volume * 100);
     const playStatsToggleLabel = showPlayStats ? t("menu.playStats.disable") : t("menu.playStats.enable");
+    const selectableLanguages = React.useMemo(
+        () => ["en", "pl", "es", "fr", "en-xa"] as const,
+        []
+    );
     const currentLanguage = (i18n.resolvedLanguage ?? i18n.language ?? "en").toLowerCase();
-    const selectedLanguage = currentLanguage.startsWith("en-xa") ? "en-xa" : "en";
+    const selectedLanguage = React.useMemo(() => {
+        const matchedLanguage = selectableLanguages.find(
+            (languageCode) =>
+                currentLanguage === languageCode || currentLanguage.startsWith(`${languageCode}-`)
+        );
+
+        return matchedLanguage ?? "en";
+    }, [currentLanguage, selectableLanguages]);
 
     React.useEffect(() => {
         if (!open) {
@@ -94,8 +105,11 @@ function HamburgerMenuImpl({
                             }}
                             aria-label={t("menu.language.label")}
                         >
-                            <option value="en">{t("menu.language.options.en")}</option>
-                            <option value="en-xa">{t("menu.language.options.en-xa")}</option>
+                            {selectableLanguages.map((languageCode) => (
+                                <option key={languageCode} value={languageCode}>
+                                    {t(`menu.language.options.${languageCode}`)}
+                                </option>
+                            ))}
                         </select>
                     </div>
 

--- a/src/components/hamburger-menu.tsx
+++ b/src/components/hamburger-menu.tsx
@@ -3,6 +3,11 @@ import { useTranslation } from "react-i18next";
 import style from "./sokoban.module.css";
 import { ThemeSwitcher } from "./theme-switcher";
 
+const BASE_SELECTABLE_LANGUAGES = ["en", "pl", "es", "fr"] as const;
+const SELECTABLE_LANGUAGES = import.meta.env.DEV
+    ? ([...BASE_SELECTABLE_LANGUAGES, "en-xa"] as const)
+    : BASE_SELECTABLE_LANGUAGES;
+
 type HamburgerMenuProps = {
     open: boolean;
     showPlayStats: boolean;
@@ -40,19 +45,12 @@ function HamburgerMenuImpl({
     const sfxSliderId = React.useId();
     const volumePercent = Math.round(volume * 100);
     const playStatsToggleLabel = showPlayStats ? t("menu.playStats.disable") : t("menu.playStats.enable");
-    const selectableLanguages = React.useMemo(
-        () => ["en", "pl", "es", "fr", "en-xa"] as const,
-        []
-    );
     const currentLanguage = (i18n.resolvedLanguage ?? i18n.language ?? "en").toLowerCase();
-    const selectedLanguage = React.useMemo(() => {
-        const matchedLanguage = selectableLanguages.find(
-            (languageCode) =>
-                currentLanguage === languageCode || currentLanguage.startsWith(`${languageCode}-`)
-        );
-
-        return matchedLanguage ?? "en";
-    }, [currentLanguage, selectableLanguages]);
+    const matchedLanguage = SELECTABLE_LANGUAGES.find(
+        (languageCode) =>
+            currentLanguage === languageCode || currentLanguage.startsWith(`${languageCode}-`)
+    );
+    const selectedLanguage = matchedLanguage ?? "en";
 
     React.useEffect(() => {
         if (!open) {
@@ -60,6 +58,12 @@ function HamburgerMenuImpl({
             setIsSfxExpanded(false);
         }
     }, [open]);
+
+    React.useEffect(() => {
+        if (!import.meta.env.DEV && currentLanguage.startsWith("en-xa")) {
+            void i18n.changeLanguage("en");
+        }
+    }, [currentLanguage, i18n]);
 
     return (
         <>
@@ -105,7 +109,7 @@ function HamburgerMenuImpl({
                             }}
                             aria-label={t("menu.language.label")}
                         >
-                            {selectableLanguages.map((languageCode) => (
+                            {SELECTABLE_LANGUAGES.map((languageCode) => (
                                 <option key={languageCode} value={languageCode}>
                                     {t(`menu.language.options.${languageCode}`)}
                                 </option>

--- a/src/components/help.tsx
+++ b/src/components/help.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from "react";
+import { useTranslation } from "react-i18next";
 import style from "./sokoban.module.css";
 import { Modal } from "./modal";
 
@@ -9,6 +10,7 @@ type HelpProps = {
 };
 
 function HelpImpl({ open: controlledOpen, showTrigger = true, onOpenChange }: HelpProps) {
+  const { t } = useTranslation();
   const [internalOpen, setInternalOpen] = useState(false);
   const suppressNextClickRef = React.useRef(false);
 
@@ -78,26 +80,26 @@ function HelpImpl({ open: controlledOpen, showTrigger = true, onOpenChange }: He
           onClick={handleClick}
           onPointerDown={handlePointerDown}
         >
-          About
+          {t("common.about")}
         </button>
       )}
 
       {open && (
         <Modal
-          title="About"
-          ariaLabel="About Sokoban"
+          title={t("help.title")}
+          ariaLabel={t("help.ariaLabel")}
           onClose={() => setOpen(false)}
           autoFocusCloseButton
         >
           {/* Version Number Injection */}
           <div style={{ textAlign: "center", marginBottom: "16px", color: "gray", fontSize: "0.9em" }}>
-            Version {__APP_VERSION__}
+            {t("common.version", { version: __APP_VERSION__ })}
           </div>
 
-          <section className={style.aboutSection} aria-label="Project links">
-            <h3 className={style.aboutSectionTitle}>Built with</h3>
-            <p className={style.aboutText}>React, TypeScript, and Vite.</p>
-            <h3 className={style.aboutSectionTitle}>Project</h3>
+          <section className={style.aboutSection} aria-label={t("help.sections.projectLinks")}>
+            <h3 className={style.aboutSectionTitle}>{t("help.builtWithTitle")}</h3>
+            <p className={style.aboutText}>{t("help.builtWithText")}</p>
+            <h3 className={style.aboutSectionTitle}>{t("help.projectTitle")}</h3>
             <div className={style.aboutLinks}>
               <a
                 className={style.aboutLink}
@@ -110,21 +112,21 @@ function HelpImpl({ open: controlledOpen, showTrigger = true, onOpenChange }: He
             </div>
           </section>
 
-          <section className={style.aboutSection} aria-label="Controls">
-            <h3 className={style.aboutSectionTitle}>Controls</h3>
+          <section className={style.aboutSection} aria-label={t("help.sections.controls")}>
+            <h3 className={style.aboutSectionTitle}>{t("help.controlsTitle")}</h3>
             <div className={style.helpRows}>
               <div>&uarr;</div>
-              <div>Move Up</div>
+              <div>{t("help.controlLabels.moveUp")}</div>
               <div>&larr;&nbsp;&rarr;</div>
-              <div>Move Left / Right</div>
+              <div>{t("help.controlLabels.moveLeftRight")}</div>
               <div>&darr;</div>
-              <div>Move Down</div>
+              <div>{t("help.controlLabels.moveDown")}</div>
               <div>Backspace</div>
-              <div>Undo</div>
+              <div>{t("help.controlLabels.undo")}</div>
               <div>Escape</div>
-              <div>Restart Level</div>
+              <div>{t("help.controlLabels.restartLevel")}</div>
               <div>[&nbsp;/&nbsp;]</div>
-              <div>Previous / Next Level</div>
+              <div>{t("help.controlLabels.previousNextLevel")}</div>
             </div>
           </section>
         </Modal>

--- a/src/components/level-selector-modal.tsx
+++ b/src/components/level-selector-modal.tsx
@@ -1,4 +1,5 @@
 import type { LevelPack } from "../hooks/levels";
+import { useTranslation } from "react-i18next";
 import { Modal } from "./modal";
 import style from "./sokoban.module.css";
 
@@ -15,6 +16,8 @@ function LevelSelectorModal({
     levelPacks,
     onSelectLevel,
 }: LevelSelectorModalProps) {
+    const { t } = useTranslation();
+
     if (!open) {
         return null;
     }
@@ -23,13 +26,13 @@ function LevelSelectorModal({
 
     return (
         <Modal
-            title="Level Packs"
-            ariaLabel="Level pack selector"
+            title={t("levelSelector.title")}
+            ariaLabel={t("levelSelector.ariaLabel")}
             onClose={() => onOpenChange(false)}
         >
             <div className={style.levelSelector}>
                 {levelPacks.map((pack, index) => {
-                    const currentPackMeta = `${pack.levels.length} levels available`;
+                    const currentPackMeta = t("levelSelector.meta", { count: pack.levels.length });
 
                     return (
                         <section className={style.levelSelectorPack} key={pack.packId}>
@@ -51,7 +54,7 @@ function LevelSelectorModal({
                                     autoFocus={index === firstPlayablePackIndex}
                                     disabled={!pack.levels.length}
                                 >
-                                    Play Pack
+                                    {t("levelSelector.playPack")}
                                 </button>
                             </div>
                         </section>

--- a/src/components/mobile-controls.tsx
+++ b/src/components/mobile-controls.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import { Direction } from "../hooks/sokoban";
 import style from "./sokoban.module.css";
 
@@ -126,6 +127,7 @@ function parseStoredPosition(raw: string | null): Position | null {
 }
 
 function MobileControls({ onMove, onUndo, onRestart }: MobileControlsProps) {
+    const { t } = useTranslation();
     const controlsRef = React.useRef<HTMLDivElement | null>(null);
     const dragRef = React.useRef<{
         pointerId: number;
@@ -272,66 +274,66 @@ function MobileControls({ onMove, onUndo, onRestart }: MobileControlsProps) {
             ref={controlsRef}
             className={`${style.mobileControlsShell} ${isDragging ? style.mobileControlsShellDragging : ""}`}
             style={{ left: `${position.x}px`, top: `${position.y}px` }}
-            aria-label="Touch controls"
+            aria-label={t("mobileControls.groupLabel")}
             role="group"
         >
             <div className={style.mobileControlActions}>
                 <button
                     type="button"
-                    aria-label="Undo move"
+                    aria-label={t("mobileControls.undo.aria")}
                     className={style.mobileControlActionButton}
                     {...undoHandlers}
                 >
-                    Undo
+                    {t("mobileControls.undo.label")}
                 </button>
                 <button
                     type="button"
-                    aria-label="Restart level"
+                    aria-label={t("mobileControls.restart.aria")}
                     className={style.mobileControlActionButton}
                     onClick={onRestart}
                     onContextMenu={onRestartContextMenu}
                 >
-                    Restart
+                    {t("mobileControls.restart.label")}
                 </button>
             </div>
 
             <div className={style.mobileControls}>
                 <button
                     type="button"
-                    aria-label="Move up"
+                    aria-label={t("mobileControls.move.up")}
                     className={`${style.mobileControlButton} ${style.mobileControlUp}`}
                     {...upHandlers}
                 >
-                    U
+                    {t("mobileControls.buttonGlyphs.up")}
                 </button>
                 <button
                     type="button"
-                    aria-label="Move left"
+                    aria-label={t("mobileControls.move.left")}
                     className={`${style.mobileControlButton} ${style.mobileControlLeft}`}
                     {...leftHandlers}
                 >
-                    L
+                    {t("mobileControls.buttonGlyphs.left")}
                 </button>
                 <button
                     type="button"
-                    aria-label="Move right"
+                    aria-label={t("mobileControls.move.right")}
                     className={`${style.mobileControlButton} ${style.mobileControlRight}`}
                     {...rightHandlers}
                 >
-                    R
+                    {t("mobileControls.buttonGlyphs.right")}
                 </button>
                 <button
                     type="button"
-                    aria-label="Move down"
+                    aria-label={t("mobileControls.move.down")}
                     className={`${style.mobileControlButton} ${style.mobileControlDown}`}
                     {...downHandlers}
                 >
-                    D
+                    {t("mobileControls.buttonGlyphs.down")}
                 </button>
                 <button
                     type="button"
-                    aria-label="Drag to move controls"
-                    title="Drag to reposition. Double tap to reset."
+                    aria-label={t("mobileControls.handle.aria")}
+                    title={t("mobileControls.handle.title")}
                     className={style.mobileControlHandle}
                     onPointerDown={onDragPointerDown}
                     onPointerMove={onDragPointerMove}
@@ -340,7 +342,7 @@ function MobileControls({ onMove, onUndo, onRestart }: MobileControlsProps) {
                     onDoubleClick={onResetPosition}
                     onContextMenu={onHandleContextMenu}
                 >
-                    <span className={style.screenReaderOnly}>Reposition controls</span>
+                    <span className={style.screenReaderOnly}>{t("mobileControls.handle.screenReader")}</span>
                 </button>
             </div>
         </div>

--- a/src/components/modal.tsx
+++ b/src/components/modal.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import style from "./sokoban.module.css";
 
 type ModalProps = {
@@ -10,6 +11,8 @@ type ModalProps = {
 };
 
 function Modal({ title, ariaLabel, onClose, children, autoFocusCloseButton = false }: ModalProps) {
+    const { t } = useTranslation();
+
     return (
         <div
             className={style.modalOverlay}
@@ -25,7 +28,7 @@ function Modal({ title, ariaLabel, onClose, children, autoFocusCloseButton = fal
                         type="button"
                         className={style.modalCloseButton}
                         onClick={onClose}
-                        aria-label="Close"
+                        aria-label={t("common.close")}
                         autoFocus={autoFocusCloseButton}
                     >
                         ×

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -54,7 +54,7 @@
 }
 
 .bestStatsBar {
-    width: min(100%, 30ch);
+    width: fit-content;
     max-width: 100%;
     box-sizing: border-box;
     display: flex;
@@ -71,20 +71,27 @@
     flex-shrink: 0;
 }
 
+.statsTable {
+    width: max-content;
+    max-width: 100%;
+    border-collapse: collapse;
+    color: inherit;
+    font-variant-numeric: tabular-nums;
+}
+
+.statsTable th,
+.statsTable td {
+    padding: 0 0.25ch;
+    vertical-align: baseline;
+}
+
 .bestStatsRow,
 .completionStatsRow {
     margin: 0;
     border: 0;
     background: none;
     color: inherit;
-    padding: 0 0.25ch;
-    display: grid;
-    grid-template-columns: 1fr 5ch 5ch 7ch;
-    column-gap: 0.8ch;
-    align-items: baseline;
     text-align: left;
-    font-variant-numeric: tabular-nums;
-    white-space: nowrap;
 }
 
 .bestStatsRow {
@@ -105,6 +112,10 @@
     text-transform: uppercase;
     letter-spacing: 0.03em;
     color: color-mix(in srgb, var(--muted) 85%, var(--foreground) 15%);
+    line-height: 1.15;
+    white-space: normal;
+    overflow-wrap: anywhere;
+    padding-bottom: 2px;
 }
 
 .statsHeaderCell:nth-child(2),
@@ -116,17 +127,12 @@
 .statsRunCell {
     text-align: left;
     white-space: nowrap;
+    font-weight: inherit;
 }
 
 .statsValueCell {
     text-align: right;
     white-space: nowrap;
-}
-
-.bestStatsRow,
-.completionStatsRow {
-    overflow: hidden;
-    text-overflow: ellipsis;
 }
 
 .menuToggleButton {
@@ -399,7 +405,7 @@
     display: flex;
     flex-direction: column;
     gap: 3px;
-    width: min(100%, 30ch);
+    width: fit-content;
     max-width: 100%;
     box-sizing: border-box;
     margin: 4px auto 18px;

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -1102,12 +1102,18 @@
 .levelBestToggleOff,
 .levelBestToggleOn {
     width: 14px;
+    height: 14px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     text-align: center;
-    font-size: 0.56rem;
-    font-weight: 800;
-    letter-spacing: 0.04em;
-    text-transform: uppercase;
     color: var(--text);
+}
+
+.togglePowerSymbol {
+    width: 11px;
+    height: 11px;
+    display: block;
 }
 
 .themeToggleCheckbox:checked+.themeToggleLabel {

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -81,16 +81,18 @@
 
 .statsTable th,
 .statsTable td {
-    padding: 0 0.90ch;
+    padding: 0;
     vertical-align: baseline;
 }
 
 .statsTable tr> :first-child {
     text-align: left;
+    padding-inline: 0 0.90ch;
 }
 
 .statsTable tr> :nth-child(n + 2) {
     text-align: right;
+    padding-inline: 0.90ch 0;
 }
 
 .bestStatsRow,

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -90,13 +90,15 @@
     padding-inline: 0 0.90ch;
 }
 
-.statsTable tr> :nth-child(n + 2) {
-    text-align: right;
-    padding-inline: 0.90ch 0;
+.statsTable tr> :nth-child(2),
+.statsTable tr> :nth-child(3) {
+    text-align: center;
+    padding-inline: 0.90ch;
 }
 
 .statsTable tr> :nth-child(4) {
-    padding-inline-start: 1.60ch;
+    text-align: right;
+    padding-inline: 1.60ch 0;
     min-width: 6ch;
 }
 

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -518,6 +518,16 @@
     font-weight: 700;
 }
 
+.menuLanguageSelect {
+    border: 1px solid var(--border);
+    background: color-mix(in srgb, var(--surface) 90%, var(--text) 10%);
+    color: var(--foreground);
+    border-radius: 10px;
+    padding: 6px 10px;
+    font-size: 0.88rem;
+    font-weight: 700;
+}
+
 .menuItemButton {
     width: 100%;
     text-align: left;
@@ -704,6 +714,7 @@
 .menuToggleButton:hover,
 .menuDrawerCloseButton:hover,
 .menuItemButton:hover,
+.menuLanguageSelect:hover,
 .modalCloseButton:hover {
     border-color: var(--accent);
 }
@@ -725,6 +736,7 @@
 .menuToggleButton:focus-visible,
 .menuDrawerCloseButton:focus-visible,
 .menuItemButton:focus-visible,
+.menuLanguageSelect:focus-visible,
 .menuSfxToggleButton:focus-visible,
 .modalCloseButton:focus-visible {
     outline: 2px solid var(--accent);

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -85,6 +85,14 @@
     vertical-align: baseline;
 }
 
+.statsTable tr> :first-child {
+    text-align: left;
+}
+
+.statsTable tr> :nth-child(n + 2) {
+    text-align: right;
+}
+
 .bestStatsRow,
 .completionStatsRow {
     margin: 0;
@@ -116,12 +124,6 @@
     white-space: normal;
     overflow-wrap: anywhere;
     padding-bottom: 2px;
-}
-
-.statsHeaderCell:nth-child(2),
-.statsHeaderCell:nth-child(3),
-.statsHeaderCell:nth-child(4) {
-    text-align: right;
 }
 
 .statsRunCell {

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -528,6 +528,18 @@
     font-weight: 700;
 }
 
+.menuLanguageSelect option,
+.menuLanguageSelect optgroup {
+    background: var(--surface);
+    color: var(--foreground);
+}
+
+/* Some Linux desktop runtimes render a light native popup even in dark mode.
+   Force a readable light popup color-scheme for this select in dark theme. */
+[data-theme="dark"] .menuLanguageSelect {
+    color-scheme: light;
+}
+
 .menuItemButton {
     width: 100%;
     text-align: left;

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -81,7 +81,7 @@
 
 .statsTable th,
 .statsTable td {
-    padding: 0 0.25ch;
+    padding: 0 0.90ch;
     vertical-align: baseline;
 }
 

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -95,6 +95,11 @@
     padding-inline: 0.90ch 0;
 }
 
+.statsTable tr> :nth-child(4) {
+    padding-inline-start: 1.60ch;
+    min-width: 6ch;
+}
+
 .bestStatsRow,
 .completionStatsRow {
     margin: 0;

--- a/src/components/sokoban.module.css
+++ b/src/components/sokoban.module.css
@@ -1111,8 +1111,8 @@
 }
 
 .togglePowerSymbol {
-    width: 11px;
-    height: 11px;
+    width: 12px;
+    height: 12px;
     display: block;
 }
 

--- a/src/components/theme-switcher.tsx
+++ b/src/components/theme-switcher.tsx
@@ -1,8 +1,10 @@
 import React from "react";
+import { useTranslation } from "react-i18next";
 import style from "./sokoban.module.css";
 import { useTheme } from "../hooks/theme";
 
 export function ThemeSwitcher() {
+    const { t } = useTranslation();
     const { setMode, resolvedTheme } = useTheme();
     const isDark = resolvedTheme === "dark";
 
@@ -19,7 +21,7 @@ export function ThemeSwitcher() {
                     type="checkbox"
                     checked={isDark}
                     onChange={handleToggle}
-                    aria-label={isDark ? "Switch to light mode" : "Switch to dark mode"}
+                    aria-label={isDark ? t("theme.switchToLight") : t("theme.switchToDark")}
                 />
                 <label htmlFor="theme-toggle" className={style.themeToggleLabel}>
                     <svg className={style.themeToggleMoon} viewBox="0 0 24 24" aria-hidden="true">

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -2,6 +2,9 @@ import i18n from "i18next";
 import LanguageDetector from "i18next-browser-languagedetector";
 import { initReactI18next } from "react-i18next";
 import enTranslation from "./locales/en/translation.json";
+import esTranslation from "./locales/es/translation.json";
+import frTranslation from "./locales/fr/translation.json";
+import plTranslation from "./locales/pl/translation.json";
 import pseudoTranslation from "./locales/en-xa/translation.json";
 
 void i18n
@@ -12,12 +15,21 @@ void i18n
             en: {
                 translation: enTranslation,
             },
+            pl: {
+                translation: plTranslation,
+            },
+            es: {
+                translation: esTranslation,
+            },
+            fr: {
+                translation: frTranslation,
+            },
             "en-xa": {
                 translation: pseudoTranslation,
             },
         },
         fallbackLng: "en",
-        supportedLngs: ["en", "en-xa"],
+        supportedLngs: ["en", "pl", "es", "fr", "en-xa"],
         nonExplicitSupportedLngs: true,
         defaultNS: "translation",
         interpolation: {

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,37 @@
+import i18n from "i18next";
+import LanguageDetector from "i18next-browser-languagedetector";
+import { initReactI18next } from "react-i18next";
+import enTranslation from "./locales/en/translation.json";
+import pseudoTranslation from "./locales/en-xa/translation.json";
+
+void i18n
+    .use(LanguageDetector)
+    .use(initReactI18next)
+    .init({
+        resources: {
+            en: {
+                translation: enTranslation,
+            },
+            "en-xa": {
+                translation: pseudoTranslation,
+            },
+        },
+        fallbackLng: "en",
+        supportedLngs: ["en", "en-xa"],
+        nonExplicitSupportedLngs: true,
+        defaultNS: "translation",
+        interpolation: {
+            escapeValue: false,
+        },
+        detection: {
+            order: ["localStorage", "navigator", "htmlTag"],
+            caches: ["localStorage"],
+            lookupLocalStorage: "sokoban-language",
+        },
+        react: {
+            useSuspense: false,
+        },
+        returnNull: false,
+    });
+
+export default i18n;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
+import "./i18n";
 import Game from "./Game";
 import { ThemeProvider } from "./hooks/theme";
 import { preloadGameAssets } from "./utils/preload-assets";

--- a/src/locales/en-xa/translation.json
+++ b/src/locales/en-xa/translation.json
@@ -1,0 +1,171 @@
+{
+    "common": {
+        "close": "[!! Close !!]",
+        "cancel": "[!! Cancel !!]",
+        "continue": "[!! Continue !!]",
+        "about": "[!! About !!]",
+        "levelPacks": "[!! Level Packs !!]",
+        "playPack": "[!! Play Pack !!]",
+        "on": "[!! On !!]",
+        "off": "[!! Off !!]",
+        "show": "[!! Show !!]",
+        "hide": "[!! Hide !!]",
+        "version": "[!! Version {{version}} !!]",
+        "language": "[!! Language !!]"
+    },
+    "game": {
+        "menu": {
+            "open": "[!! Open menu !!]",
+            "close": "[!! Close menu !!]"
+        },
+        "levelPicker": {
+            "label": "[!! Level picker !!]",
+            "previous": "[!! Previous Level !!]",
+            "next": "[!! Next Level !!]",
+            "openSelector": "[!! Open level selector !!]",
+            "fallbackPackName": "[!! Levels !!]"
+        },
+        "playStats": {
+            "regionLabel": "[!! Play statistics !!]",
+            "runAndBestLabel": "[!! Run and best records !!]"
+        },
+        "board": {
+            "label": "[!! Sokoban board !!]"
+        },
+        "stats": {
+            "header": {
+                "run": "[!! Run !!]",
+                "moves": "[!! Moves !!]",
+                "undos": "[!! Undos !!]",
+                "time": "[!! Time !!]"
+            },
+            "run": {
+                "current": "[!! Current !!]",
+                "best": "[!! Best !!]"
+            },
+            "aria": {
+                "current": "[!! Current: Moves {{moves}} Undos {{undos}} Time {{time}} !!]",
+                "best": "[!! Best: Moves {{moves}} Undos {{undos}} Time {{time}} !!]"
+            }
+        },
+        "confirmation": {
+            "restart": {
+                "title": "[!! Restart level? !!]",
+                "ariaLabel": "[!! Restart level confirmation !!]",
+                "warning": "[!! Restarting now will erase your progress on this level. !!]",
+                "confirm": "[!! Restart Level !!]"
+            },
+            "switch": {
+                "title": "[!! Switch level? !!]",
+                "warning": "[!! Switching levels now will erase your progress on this level. !!]",
+                "previousAriaLabel": "[!! Switch to previous level confirmation !!]",
+                "previousConfirm": "[!! Go to Previous Level !!]",
+                "nextAriaLabel": "[!! Switch to next level confirmation !!]",
+                "nextConfirm": "[!! Go to Next Level !!]",
+                "selectedAriaLabel": "[!! Switch to selected level confirmation !!]",
+                "selectedConfirm": "[!! Go to Selected Level !!]"
+            },
+            "resetStats": {
+                "title": "[!! Reset stats? !!]",
+                "ariaLabel": "[!! Reset stats confirmation !!]",
+                "warning": "[!! Resetting stats will permanently remove your saved moves, undos, and times. !!]",
+                "confirm": "[!! Reset Stats !!]"
+            }
+        },
+        "completion": {
+            "ariaLabel": "[!! Level completed !!]",
+            "title": {
+                "congratulations": "[!! Congratulations! !!]",
+                "packComplete": "[!! Level Pack Complete! !!]"
+            },
+            "message": {
+                "levelComplete": "[!! You completed this level. !!]",
+                "packComplete": "[!! You completed the last level in this pack. !!]",
+                "packSwitch": "[!! Switch to a different level pack from the <levelPacks>Level Packs</levelPacks> selector, or press <continue>Continue</continue> to return to Level 1 in this pack. !!]"
+            }
+        }
+    },
+    "menu": {
+        "ariaLabel": "[!! Game menu !!]",
+        "title": "[!! Menu !!]",
+        "theme": "[!! Theme !!]",
+        "language": {
+            "label": "[!! Language !!]",
+            "options": {
+                "en": "[!! English !!]",
+                "en-xa": "[!! Pseudo (Test) !!]"
+            }
+        },
+        "playStats": {
+            "title": "[!! Play Stats !!]",
+            "visible": "[!! Visible !!]",
+            "enable": "[!! Enable play stats !!]",
+            "disable": "[!! Disable play stats !!]",
+            "reset": "[!! Reset Stats !!]"
+        },
+        "sfx": {
+            "title": "[!! SFX Settings !!]",
+            "mute": "[!! Mute SFX !!]",
+            "volume": "[!! Volume !!]",
+            "volumeAria": "[!! SFX volume !!]"
+        }
+    },
+    "help": {
+        "title": "[!! About !!]",
+        "ariaLabel": "[!! About Sokoban !!]",
+        "sections": {
+            "projectLinks": "[!! Project links !!]",
+            "controls": "[!! Controls !!]"
+        },
+        "builtWithTitle": "[!! Built with !!]",
+        "builtWithText": "[!! React, TypeScript, and Vite. !!]",
+        "projectTitle": "[!! Project !!]",
+        "controlsTitle": "[!! Controls !!]",
+        "controlLabels": {
+            "moveUp": "[!! Move Up !!]",
+            "moveLeftRight": "[!! Move Left / Right !!]",
+            "moveDown": "[!! Move Down !!]",
+            "undo": "[!! Undo !!]",
+            "restartLevel": "[!! Restart Level !!]",
+            "previousNextLevel": "[!! Previous / Next Level !!]"
+        }
+    },
+    "levelSelector": {
+        "title": "[!! Level Packs !!]",
+        "ariaLabel": "[!! Level pack selector !!]",
+        "meta": "[!! {{count}} levels available !!]",
+        "playPack": "[!! Play Pack !!]"
+    },
+    "mobileControls": {
+        "groupLabel": "[!! Touch controls !!]",
+        "undo": {
+            "aria": "[!! Undo move !!]",
+            "label": "[!! Undo !!]"
+        },
+        "restart": {
+            "aria": "[!! Restart level !!]",
+            "label": "[!! Restart !!]"
+        },
+        "move": {
+            "up": "[!! Move up !!]",
+            "left": "[!! Move left !!]",
+            "right": "[!! Move right !!]",
+            "down": "[!! Move down !!]"
+        },
+        "handle": {
+            "aria": "[!! Drag to move controls !!]",
+            "title": "[!! Drag to reposition. Double tap to reset. !!]",
+            "screenReader": "[!! Reposition controls !!]"
+        },
+        "buttonGlyphs": {
+            "up": "[!! U !!]",
+            "left": "[!! L !!]",
+            "right": "[!! R !!]",
+            "down": "[!! D !!]"
+        }
+    },
+    "theme": {
+        "switchToLight": "[!! Switch to light mode !!]",
+        "switchToDark": "[!! Switch to dark mode !!]"
+    }
+}

--- a/src/locales/en-xa/translation.json
+++ b/src/locales/en-xa/translation.json
@@ -93,6 +93,9 @@
             "label": "[!! Language !!]",
             "options": {
                 "en": "[!! English !!]",
+                "pl": "[!! Polish !!]",
+                "es": "[!! Spanish !!]",
+                "fr": "[!! French !!]",
                 "en-xa": "[!! Pseudo (Test) !!]"
             }
         },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -93,6 +93,9 @@
             "label": "Language",
             "options": {
                 "en": "English",
+                "pl": "Polish",
+                "es": "Spanish",
+                "fr": "French",
                 "en-xa": "Pseudo (Test)"
             }
         },

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,0 +1,171 @@
+{
+    "common": {
+        "close": "Close",
+        "cancel": "Cancel",
+        "continue": "Continue",
+        "about": "About",
+        "levelPacks": "Level Packs",
+        "playPack": "Play Pack",
+        "on": "On",
+        "off": "Off",
+        "show": "Show",
+        "hide": "Hide",
+        "version": "Version {{version}}",
+        "language": "Language"
+    },
+    "game": {
+        "menu": {
+            "open": "Open menu",
+            "close": "Close menu"
+        },
+        "levelPicker": {
+            "label": "Level picker",
+            "previous": "Previous Level",
+            "next": "Next Level",
+            "openSelector": "Open level selector",
+            "fallbackPackName": "Levels"
+        },
+        "playStats": {
+            "regionLabel": "Play statistics",
+            "runAndBestLabel": "Run and best records"
+        },
+        "board": {
+            "label": "Sokoban board"
+        },
+        "stats": {
+            "header": {
+                "run": "Run",
+                "moves": "Moves",
+                "undos": "Undos",
+                "time": "Time"
+            },
+            "run": {
+                "current": "Current",
+                "best": "Best"
+            },
+            "aria": {
+                "current": "Current: Moves {{moves}} Undos {{undos}} Time {{time}}",
+                "best": "Best: Moves {{moves}} Undos {{undos}} Time {{time}}"
+            }
+        },
+        "confirmation": {
+            "restart": {
+                "title": "Restart level?",
+                "ariaLabel": "Restart level confirmation",
+                "warning": "Restarting now will erase your progress on this level.",
+                "confirm": "Restart Level"
+            },
+            "switch": {
+                "title": "Switch level?",
+                "warning": "Switching levels now will erase your progress on this level.",
+                "previousAriaLabel": "Switch to previous level confirmation",
+                "previousConfirm": "Go to Previous Level",
+                "nextAriaLabel": "Switch to next level confirmation",
+                "nextConfirm": "Go to Next Level",
+                "selectedAriaLabel": "Switch to selected level confirmation",
+                "selectedConfirm": "Go to Selected Level"
+            },
+            "resetStats": {
+                "title": "Reset stats?",
+                "ariaLabel": "Reset stats confirmation",
+                "warning": "Resetting stats will permanently remove your saved moves, undos, and times.",
+                "confirm": "Reset Stats"
+            }
+        },
+        "completion": {
+            "ariaLabel": "Level completed",
+            "title": {
+                "congratulations": "Congratulations!",
+                "packComplete": "Level Pack Complete!"
+            },
+            "message": {
+                "levelComplete": "You completed this level.",
+                "packComplete": "You completed the last level in this pack.",
+                "packSwitch": "Switch to a different level pack from the <levelPacks>Level Packs</levelPacks> selector, or press <continue>Continue</continue> to return to Level 1 in this pack."
+            }
+        }
+    },
+    "menu": {
+        "ariaLabel": "Game menu",
+        "title": "Menu",
+        "theme": "Theme",
+        "language": {
+            "label": "Language",
+            "options": {
+                "en": "English",
+                "en-xa": "Pseudo (Test)"
+            }
+        },
+        "playStats": {
+            "title": "Play Stats",
+            "visible": "Visible",
+            "enable": "Enable play stats",
+            "disable": "Disable play stats",
+            "reset": "Reset Stats"
+        },
+        "sfx": {
+            "title": "SFX Settings",
+            "mute": "Mute SFX",
+            "volume": "Volume",
+            "volumeAria": "SFX volume"
+        }
+    },
+    "help": {
+        "title": "About",
+        "ariaLabel": "About Sokoban",
+        "sections": {
+            "projectLinks": "Project links",
+            "controls": "Controls"
+        },
+        "builtWithTitle": "Built with",
+        "builtWithText": "React, TypeScript, and Vite.",
+        "projectTitle": "Project",
+        "controlsTitle": "Controls",
+        "controlLabels": {
+            "moveUp": "Move Up",
+            "moveLeftRight": "Move Left / Right",
+            "moveDown": "Move Down",
+            "undo": "Undo",
+            "restartLevel": "Restart Level",
+            "previousNextLevel": "Previous / Next Level"
+        }
+    },
+    "levelSelector": {
+        "title": "Level Packs",
+        "ariaLabel": "Level pack selector",
+        "meta": "{{count}} levels available",
+        "playPack": "Play Pack"
+    },
+    "mobileControls": {
+        "groupLabel": "Touch controls",
+        "undo": {
+            "aria": "Undo move",
+            "label": "Undo"
+        },
+        "restart": {
+            "aria": "Restart level",
+            "label": "Restart"
+        },
+        "move": {
+            "up": "Move up",
+            "left": "Move left",
+            "right": "Move right",
+            "down": "Move down"
+        },
+        "handle": {
+            "aria": "Drag to move controls",
+            "title": "Drag to reposition. Double tap to reset.",
+            "screenReader": "Reposition controls"
+        },
+        "buttonGlyphs": {
+            "up": "U",
+            "left": "L",
+            "right": "R",
+            "down": "D"
+        }
+    },
+    "theme": {
+        "switchToLight": "Switch to light mode",
+        "switchToDark": "Switch to dark mode"
+    }
+}

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1,0 +1,174 @@
+{
+    "common": {
+        "close": "Cerrar",
+        "cancel": "Cancelar",
+        "continue": "Continuar",
+        "about": "Acerca de",
+        "levelPacks": "Paquetes de niveles",
+        "playPack": "Jugar paquete",
+        "on": "Activado",
+        "off": "Desactivado",
+        "show": "Mostrar",
+        "hide": "Ocultar",
+        "version": "Versión {{version}}",
+        "language": "Idioma"
+    },
+    "game": {
+        "menu": {
+            "open": "Abrir menú",
+            "close": "Cerrar menú"
+        },
+        "levelPicker": {
+            "label": "Selector de nivel",
+            "previous": "Nivel anterior",
+            "next": "Nivel siguiente",
+            "openSelector": "Abrir selector de nivel",
+            "fallbackPackName": "Niveles"
+        },
+        "playStats": {
+            "regionLabel": "Estadísticas de juego",
+            "runAndBestLabel": "Partida actual y mejores marcas"
+        },
+        "board": {
+            "label": "Tablero Sokoban"
+        },
+        "stats": {
+            "header": {
+                "run": "Partida",
+                "moves": "Movimientos",
+                "undos": "Deshacer",
+                "time": "Tiempo"
+            },
+            "run": {
+                "current": "Actual",
+                "best": "Mejor"
+            },
+            "aria": {
+                "current": "Actual: Movimientos {{moves}} Deshacer {{undos}} Tiempo {{time}}",
+                "best": "Mejor: Movimientos {{moves}} Deshacer {{undos}} Tiempo {{time}}"
+            }
+        },
+        "confirmation": {
+            "restart": {
+                "title": "¿Reiniciar nivel?",
+                "ariaLabel": "Confirmación para reiniciar nivel",
+                "warning": "Si reinicias ahora, se borrará tu progreso en este nivel.",
+                "confirm": "Reiniciar nivel"
+            },
+            "switch": {
+                "title": "¿Cambiar nivel?",
+                "warning": "Si cambias de nivel ahora, se borrará tu progreso en este nivel.",
+                "previousAriaLabel": "Confirmación para ir al nivel anterior",
+                "previousConfirm": "Ir al nivel anterior",
+                "nextAriaLabel": "Confirmación para ir al nivel siguiente",
+                "nextConfirm": "Ir al nivel siguiente",
+                "selectedAriaLabel": "Confirmación para ir al nivel seleccionado",
+                "selectedConfirm": "Ir al nivel seleccionado"
+            },
+            "resetStats": {
+                "title": "¿Restablecer estadísticas?",
+                "ariaLabel": "Confirmación para restablecer estadísticas",
+                "warning": "Al restablecer estadísticas se eliminarán de forma permanente tus movimientos, deshacer y tiempos guardados.",
+                "confirm": "Restablecer estadísticas"
+            }
+        },
+        "completion": {
+            "ariaLabel": "Nivel completado",
+            "title": {
+                "congratulations": "¡Felicidades!",
+                "packComplete": "¡Pack de niveles completado!"
+            },
+            "message": {
+                "levelComplete": "Completaste este nivel.",
+                "packComplete": "Completaste el último nivel de este pack.",
+                "packSwitch": "Cambia a otro pack de niveles desde el selector de <levelPacks>Paquetes de niveles</levelPacks>, o pulsa <continue>Continuar</continue> para volver al Nivel 1 en este pack."
+            }
+        }
+    },
+    "menu": {
+        "ariaLabel": "Menú del juego",
+        "title": "Menú",
+        "theme": "Tema",
+        "language": {
+            "label": "Idioma",
+            "options": {
+                "en": "Inglés",
+                "pl": "Polaco",
+                "es": "Español",
+                "fr": "Francés",
+                "en-xa": "Pseudo (Prueba)"
+            }
+        },
+        "playStats": {
+            "title": "Estadísticas de juego",
+            "visible": "Visible",
+            "enable": "Activar estadísticas de juego",
+            "disable": "Desactivar estadísticas de juego",
+            "reset": "Restablecer estadísticas"
+        },
+        "sfx": {
+            "title": "Opciones de SFX",
+            "mute": "Silenciar SFX",
+            "volume": "Volumen",
+            "volumeAria": "Volumen de SFX"
+        }
+    },
+    "help": {
+        "title": "Acerca de",
+        "ariaLabel": "Acerca de Sokoban",
+        "sections": {
+            "projectLinks": "Enlaces del proyecto",
+            "controls": "Controles"
+        },
+        "builtWithTitle": "Construido con",
+        "builtWithText": "React, TypeScript y Vite.",
+        "projectTitle": "Proyecto",
+        "controlsTitle": "Controles",
+        "controlLabels": {
+            "moveUp": "Mover arriba",
+            "moveLeftRight": "Mover izquierda / derecha",
+            "moveDown": "Mover abajo",
+            "undo": "Deshacer",
+            "restartLevel": "Reiniciar nivel",
+            "previousNextLevel": "Nivel anterior / siguiente"
+        }
+    },
+    "levelSelector": {
+        "title": "Paquetes de niveles",
+        "ariaLabel": "Selector de paquetes de niveles",
+        "meta": "{{count}} niveles disponibles",
+        "playPack": "Jugar paquete"
+    },
+    "mobileControls": {
+        "groupLabel": "Controles táctiles",
+        "undo": {
+            "aria": "Deshacer movimiento",
+            "label": "Deshacer"
+        },
+        "restart": {
+            "aria": "Reiniciar nivel",
+            "label": "Reiniciar"
+        },
+        "move": {
+            "up": "Mover arriba",
+            "left": "Mover izquierda",
+            "right": "Mover derecha",
+            "down": "Mover abajo"
+        },
+        "handle": {
+            "aria": "Arrastrar para mover controles",
+            "title": "Arrastra para recolocar. Doble toque para restablecer.",
+            "screenReader": "Recolocar controles"
+        },
+        "buttonGlyphs": {
+            "up": "U",
+            "left": "L",
+            "right": "R",
+            "down": "D"
+        }
+    },
+    "theme": {
+        "switchToLight": "Cambiar a modo claro",
+        "switchToDark": "Cambiar a modo oscuro"
+    }
+}

--- a/src/locales/fr/translation.json
+++ b/src/locales/fr/translation.json
@@ -1,0 +1,174 @@
+{
+    "common": {
+        "close": "Fermer",
+        "cancel": "Annuler",
+        "continue": "Continuer",
+        "about": "À propos",
+        "levelPacks": "Packs de niveaux",
+        "playPack": "Jouer le pack",
+        "on": "Activé",
+        "off": "Désactivé",
+        "show": "Afficher",
+        "hide": "Masquer",
+        "version": "Version {{version}}",
+        "language": "Langue"
+    },
+    "game": {
+        "menu": {
+            "open": "Ouvrir le menu",
+            "close": "Fermer le menu"
+        },
+        "levelPicker": {
+            "label": "Sélecteur de niveau",
+            "previous": "Niveau précédent",
+            "next": "Niveau suivant",
+            "openSelector": "Ouvrir le sélecteur de niveau",
+            "fallbackPackName": "Niveaux"
+        },
+        "playStats": {
+            "regionLabel": "Statistiques de jeu",
+            "runAndBestLabel": "Partie en cours et meilleurs résultats"
+        },
+        "board": {
+            "label": "Plateau Sokoban"
+        },
+        "stats": {
+            "header": {
+                "run": "Partie",
+                "moves": "Mouvements",
+                "undos": "Annulations",
+                "time": "Temps"
+            },
+            "run": {
+                "current": "Actuelle",
+                "best": "Meilleure"
+            },
+            "aria": {
+                "current": "Actuelle: Mouvements {{moves}} Annulations {{undos}} Temps {{time}}",
+                "best": "Meilleure: Mouvements {{moves}} Annulations {{undos}} Temps {{time}}"
+            }
+        },
+        "confirmation": {
+            "restart": {
+                "title": "Redémarrer le niveau ?",
+                "ariaLabel": "Confirmation de redémarrage du niveau",
+                "warning": "Redémarrer maintenant effacera votre progression sur ce niveau.",
+                "confirm": "Redémarrer le niveau"
+            },
+            "switch": {
+                "title": "Changer de niveau ?",
+                "warning": "Changer de niveau maintenant effacera votre progression sur ce niveau.",
+                "previousAriaLabel": "Confirmation de passage au niveau précédent",
+                "previousConfirm": "Aller au niveau précédent",
+                "nextAriaLabel": "Confirmation de passage au niveau suivant",
+                "nextConfirm": "Aller au niveau suivant",
+                "selectedAriaLabel": "Confirmation de passage au niveau sélectionné",
+                "selectedConfirm": "Aller au niveau sélectionné"
+            },
+            "resetStats": {
+                "title": "Réinitialiser les statistiques ?",
+                "ariaLabel": "Confirmation de réinitialisation des statistiques",
+                "warning": "Réinitialiser les statistiques supprimera définitivement vos mouvements, annulations et temps sauvegardés.",
+                "confirm": "Réinitialiser les statistiques"
+            }
+        },
+        "completion": {
+            "ariaLabel": "Niveau terminé",
+            "title": {
+                "congratulations": "Félicitations !",
+                "packComplete": "Pack de niveaux terminé !"
+            },
+            "message": {
+                "levelComplete": "Vous avez terminé ce niveau.",
+                "packComplete": "Vous avez terminé le dernier niveau de ce pack.",
+                "packSwitch": "Passez à un autre pack de niveaux depuis le sélecteur <levelPacks>Packs de niveaux</levelPacks>, ou appuyez sur <continue>Continuer</continue> pour revenir au Niveau 1 de ce pack."
+            }
+        }
+    },
+    "menu": {
+        "ariaLabel": "Menu du jeu",
+        "title": "Menu",
+        "theme": "Thème",
+        "language": {
+            "label": "Langue",
+            "options": {
+                "en": "Anglais",
+                "pl": "Polonais",
+                "es": "Espagnol",
+                "fr": "Français",
+                "en-xa": "Pseudo (Test)"
+            }
+        },
+        "playStats": {
+            "title": "Statistiques de jeu",
+            "visible": "Visible",
+            "enable": "Activer les statistiques de jeu",
+            "disable": "Désactiver les statistiques de jeu",
+            "reset": "Réinitialiser les statistiques"
+        },
+        "sfx": {
+            "title": "Paramètres SFX",
+            "mute": "Couper le son SFX",
+            "volume": "Volume",
+            "volumeAria": "Volume SFX"
+        }
+    },
+    "help": {
+        "title": "À propos",
+        "ariaLabel": "À propos de Sokoban",
+        "sections": {
+            "projectLinks": "Liens du projet",
+            "controls": "Commandes"
+        },
+        "builtWithTitle": "Construit avec",
+        "builtWithText": "React, TypeScript et Vite.",
+        "projectTitle": "Projet",
+        "controlsTitle": "Commandes",
+        "controlLabels": {
+            "moveUp": "Déplacer vers le haut",
+            "moveLeftRight": "Déplacer à gauche / droite",
+            "moveDown": "Déplacer vers le bas",
+            "undo": "Annuler",
+            "restartLevel": "Redémarrer le niveau",
+            "previousNextLevel": "Niveau précédent / suivant"
+        }
+    },
+    "levelSelector": {
+        "title": "Packs de niveaux",
+        "ariaLabel": "Sélecteur de packs de niveaux",
+        "meta": "{{count}} niveaux disponibles",
+        "playPack": "Jouer le pack"
+    },
+    "mobileControls": {
+        "groupLabel": "Commandes tactiles",
+        "undo": {
+            "aria": "Annuler le mouvement",
+            "label": "Annuler"
+        },
+        "restart": {
+            "aria": "Redémarrer le niveau",
+            "label": "Redémarrer"
+        },
+        "move": {
+            "up": "Déplacer vers le haut",
+            "left": "Déplacer à gauche",
+            "right": "Déplacer à droite",
+            "down": "Déplacer vers le bas"
+        },
+        "handle": {
+            "aria": "Glisser pour déplacer les commandes",
+            "title": "Glissez pour repositionner. Double tapez pour réinitialiser.",
+            "screenReader": "Repositionner les commandes"
+        },
+        "buttonGlyphs": {
+            "up": "U",
+            "left": "L",
+            "right": "R",
+            "down": "D"
+        }
+    },
+    "theme": {
+        "switchToLight": "Passer au mode clair",
+        "switchToDark": "Passer au mode sombre"
+    }
+}

--- a/src/locales/pl/translation.json
+++ b/src/locales/pl/translation.json
@@ -1,0 +1,174 @@
+{
+    "common": {
+        "close": "Zamknij",
+        "cancel": "Anuluj",
+        "continue": "Kontynuuj",
+        "about": "O grze",
+        "levelPacks": "Paczki poziomów",
+        "playPack": "Graj paczkę",
+        "on": "Wł.",
+        "off": "Wył.",
+        "show": "Pokaż",
+        "hide": "Ukryj",
+        "version": "Wersja {{version}}",
+        "language": "Język"
+    },
+    "game": {
+        "menu": {
+            "open": "Otwórz menu",
+            "close": "Zamknij menu"
+        },
+        "levelPicker": {
+            "label": "Wybór poziomu",
+            "previous": "Poprzedni poziom",
+            "next": "Następny poziom",
+            "openSelector": "Otwórz wybór poziomu",
+            "fallbackPackName": "Poziomy"
+        },
+        "playStats": {
+            "regionLabel": "Statystyki gry",
+            "runAndBestLabel": "Bieżący przebieg i najlepsze wyniki"
+        },
+        "board": {
+            "label": "Plansza Sokoban"
+        },
+        "stats": {
+            "header": {
+                "run": "Próba",
+                "moves": "Ruchy",
+                "undos": "Cofnięcia",
+                "time": "Czas"
+            },
+            "run": {
+                "current": "Bieżący",
+                "best": "Najlepszy"
+            },
+            "aria": {
+                "current": "Bieżący: Ruchy {{moves}} Cofnięcia {{undos}} Czas {{time}}",
+                "best": "Najlepszy: Ruchy {{moves}} Cofnięcia {{undos}} Czas {{time}}"
+            }
+        },
+        "confirmation": {
+            "restart": {
+                "title": "Zrestartować poziom?",
+                "ariaLabel": "Potwierdzenie restartu poziomu",
+                "warning": "Restart teraz usunie twój postęp na tym poziomie.",
+                "confirm": "Restartuj poziom"
+            },
+            "switch": {
+                "title": "Zmienić poziom?",
+                "warning": "Zmiana poziomu teraz usunie twój postęp na tym poziomie.",
+                "previousAriaLabel": "Potwierdzenie przejścia do poprzedniego poziomu",
+                "previousConfirm": "Przejdź do poprzedniego poziomu",
+                "nextAriaLabel": "Potwierdzenie przejścia do następnego poziomu",
+                "nextConfirm": "Przejdź do następnego poziomu",
+                "selectedAriaLabel": "Potwierdzenie przejścia do wybranego poziomu",
+                "selectedConfirm": "Przejdź do wybranego poziomu"
+            },
+            "resetStats": {
+                "title": "Zresetować statystyki?",
+                "ariaLabel": "Potwierdzenie resetu statystyk",
+                "warning": "Reset statystyk trwale usunie zapisane ruchy, cofnięcia i czasy.",
+                "confirm": "Resetuj statystyki"
+            }
+        },
+        "completion": {
+            "ariaLabel": "Poziom ukończony",
+            "title": {
+                "congratulations": "Gratulacje!",
+                "packComplete": "Paczka poziomów ukończona!"
+            },
+            "message": {
+                "levelComplete": "Ukończyłeś ten poziom.",
+                "packComplete": "Ukończyłeś ostatni poziom w tej paczce.",
+                "packSwitch": "Przełącz na inną paczkę poziomów w selektorze <levelPacks>Paczki poziomów</levelPacks>, albo naciśnij <continue>Kontynuuj</continue>, aby wrócić do Poziomu 1 w tej paczce."
+            }
+        }
+    },
+    "menu": {
+        "ariaLabel": "Menu gry",
+        "title": "Menu",
+        "theme": "Motyw",
+        "language": {
+            "label": "Język",
+            "options": {
+                "en": "Angielski",
+                "pl": "Polski",
+                "es": "Hiszpański",
+                "fr": "Francuski",
+                "en-xa": "Pseudo (Test)"
+            }
+        },
+        "playStats": {
+            "title": "Statystyki gry",
+            "visible": "Widoczne",
+            "enable": "Włącz statystyki gry",
+            "disable": "Wyłącz statystyki gry",
+            "reset": "Resetuj statystyki"
+        },
+        "sfx": {
+            "title": "Ustawienia SFX",
+            "mute": "Wycisz SFX",
+            "volume": "Głośność",
+            "volumeAria": "Głośność SFX"
+        }
+    },
+    "help": {
+        "title": "O grze",
+        "ariaLabel": "O Sokoban",
+        "sections": {
+            "projectLinks": "Linki projektu",
+            "controls": "Sterowanie"
+        },
+        "builtWithTitle": "Zbudowano z",
+        "builtWithText": "React, TypeScript i Vite.",
+        "projectTitle": "Projekt",
+        "controlsTitle": "Sterowanie",
+        "controlLabels": {
+            "moveUp": "Ruch w górę",
+            "moveLeftRight": "Ruch w lewo / prawo",
+            "moveDown": "Ruch w dół",
+            "undo": "Cofnij",
+            "restartLevel": "Restartuj poziom",
+            "previousNextLevel": "Poprzedni / Następny poziom"
+        }
+    },
+    "levelSelector": {
+        "title": "Paczki poziomów",
+        "ariaLabel": "Selektor paczek poziomów",
+        "meta": "{{count}} dostępnych poziomów",
+        "playPack": "Graj paczkę"
+    },
+    "mobileControls": {
+        "groupLabel": "Sterowanie dotykowe",
+        "undo": {
+            "aria": "Cofnij ruch",
+            "label": "Cofnij"
+        },
+        "restart": {
+            "aria": "Restartuj poziom",
+            "label": "Restartuj"
+        },
+        "move": {
+            "up": "Ruch w górę",
+            "left": "Ruch w lewo",
+            "right": "Ruch w prawo",
+            "down": "Ruch w dół"
+        },
+        "handle": {
+            "aria": "Przeciągnij, aby przesunąć sterowanie",
+            "title": "Przeciągnij, aby zmienić położenie. Podwójne stuknięcie resetuje.",
+            "screenReader": "Zmień położenie sterowania"
+        },
+        "buttonGlyphs": {
+            "up": "U",
+            "left": "L",
+            "right": "R",
+            "down": "D"
+        }
+    },
+    "theme": {
+        "switchToLight": "Przełącz na jasny motyw",
+        "switchToDark": "Przełącz na ciemny motyw"
+    }
+}

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,5 +1,7 @@
-// jest-dom adds custom jest matchers for asserting on DOM nodes.
-// allows you to do things like:
-// expect(element).toHaveTextContent(/react/i)
-// learn more: https://github.com/testing-library/jest-dom
-import '@testing-library/jest-dom/extend-expect';
+import "@testing-library/jest-dom/vitest";
+import { beforeEach } from "vitest";
+import i18n from "./i18n";
+
+beforeEach(() => {
+    void i18n.changeLanguage("en");
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,5 +11,6 @@ export default defineConfig({
     test: {
         testTimeout: 15000,
         hookTimeout: 15000,
+        setupFiles: ["./src/setupTests.ts"],
     },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -63,6 +63,11 @@
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.6.tgz#d267a43cb1836dc4d182cce93ae75ba954ef6d2b"
   integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
 
+"@babel/runtime@^7.23.2", "@babel/runtime@^7.29.2":
+  version "7.29.2"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.29.2.tgz#9a6e2d05f4b6692e1801cd4fb176ad823930ed5e"
+  integrity sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==
+
 "@bramus/specificity@^2.4.2":
   version "2.4.2"
   resolved "https://registry.yarnpkg.com/@bramus/specificity/-/specificity-2.4.2.tgz#aa8db8eb173fdee7324f82284833106adeecc648"
@@ -1875,6 +1880,13 @@ html-encoding-sniffer@^6.0.0:
   dependencies:
     "@exodus/bytes" "^1.6.0"
 
+html-parse-stringify@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/html-parse-stringify/-/html-parse-stringify-3.0.1.tgz#dfc1017347ce9f77c8141a507f233040c59c55d2"
+  integrity sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==
+  dependencies:
+    void-elements "3.1.0"
+
 http-cache-semantics@^4.0.0, http-cache-semantics@^4.1.1:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz#205f4db64f8562b76a4ff9235aa5279839a09dd5"
@@ -1903,6 +1915,18 @@ https-proxy-agent@^7.0.0, https-proxy-agent@^7.0.1:
   dependencies:
     agent-base "^7.1.2"
     debug "4"
+
+i18next-browser-languagedetector@^8.2.1:
+  version "8.2.1"
+  resolved "https://registry.yarnpkg.com/i18next-browser-languagedetector/-/i18next-browser-languagedetector-8.2.1.tgz#f17a918d376a97aa12a5b63fd8ea559a6231935b"
+  integrity sha512-bZg8+4bdmaOiApD7N7BPT9W8MLZG+nPTOFlLiJiT8uzKXFjhxw4v2ierCXOwB5sFDMtuA5G4kgYZ0AznZxQ/cw==
+  dependencies:
+    "@babel/runtime" "^7.23.2"
+
+i18next@^26.1.0:
+  version "26.1.0"
+  resolved "https://registry.yarnpkg.com/i18next/-/i18next-26.1.0.tgz#b0e7e2a3a87554781038899299658b1b5d678cb6"
+  integrity sha512-dIU6td04DvQuIqVst5S9g0GviTmhZ0DYD4b9ociVGJmuCa5vZ2de/t+Enf4olvj87mF8Y2lwjNQBwC9QZsvzKQ==
 
 iconv-corefoundation@^1.1.7:
   version "1.1.7"
@@ -2732,6 +2756,15 @@ react-dom@19:
   dependencies:
     scheduler "^0.27.0"
 
+react-i18next@^17.0.7:
+  version "17.0.7"
+  resolved "https://registry.yarnpkg.com/react-i18next/-/react-i18next-17.0.7.tgz#f66e0f9a336e31b641d89bcb654d4aee21b5409c"
+  integrity sha512-rwtPXsb/zwzDafN+gytcjF5YnqGQQIRmCQ6DctBC1VSipRB8GD/MWEVrFP42vjMyuYydxWxM8CZRt+yiNuuoHg==
+  dependencies:
+    "@babel/runtime" "^7.29.2"
+    html-parse-stringify "^3.0.1"
+    use-sync-external-store "^1.6.0"
+
 react-is@^17.0.1:
   version "17.0.2"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
@@ -3324,6 +3357,11 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
+use-sync-external-store@^1.6.0:
+  version "1.6.0"
+  resolved "https://registry.yarnpkg.com/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz#b174bfa65cb2b526732d9f2ac0a408027876f32d"
+  integrity sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==
+
 utf8-byte-length@^1.0.1:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/utf8-byte-length/-/utf8-byte-length-1.0.5.tgz#f9f63910d15536ee2b2d5dd4665389715eac5c1e"
@@ -3381,6 +3419,11 @@ vitest@^4.1.0:
     tinyrainbow "^3.1.0"
     vite "^6.0.0 || ^7.0.0 || ^8.0.0"
     why-is-node-running "^2.3.0"
+
+void-elements@3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/void-elements/-/void-elements-3.1.0.tgz#614f7fbf8d801f0bb5f0661f5b2f5785750e4f09"
+  integrity sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==
 
 w3c-xmlserializer@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
### Description
This Pull Request delivers full internationalization (i18n) for the game UI and implements a series of structural and visual refinements to the in-game statistics display. It transitions from static English text to a robust, scalable translation architecture powered by `i18next`, and introduces Polish, Spanish, and French language packs alongside a developer pseudo-locale.

### Key Changes
* **Core Internationalization (i18n):**
  * Integrated `i18next` and `react-i18next` to manage application-wide translations.
  * Extracted hardcoded English strings across all core UI components (`Game`, `HamburgerMenu`, `Help`, `LevelSelectorModal`, `MobileControls`, `Modal`, `ThemeSwitcher`) into standardized JSON locale files.
  * Added `i18next-browser-languagedetector` to automatically infer and persist the user's preferred language.
* **Language Support & Toggles:**
  * Implemented initial translations for Polish (`pl`), Spanish (`es`), and French (`fr`), alongside a pseudo-translation (`en-xa`) for QA and boundary testing.
  * Added a dynamic language dropdown to the `HamburgerMenu`. The dropdown correctly renders self-localized language names and falls back gracefully when handling regional variants (e.g., matching `es-MX` to `es`).
  * Enforced environment-aware rendering: the `en-xa` pseudo-locale is completely stripped from production builds via `import.meta.env.DEV` to ensure a professional user experience.
* **UI & Structural Refinements:**
  * Replaced the confusing "On/Off" text in the menu toggles (Play Stats, SFX) with intuitive, scalable SVG power symbols (`ToggleOnSymbol`, `ToggleOffSymbol`) for better cross-language consistency.
  * Completely refactored the `StatsTable` component to use semantic HTML `<table>`, `<thead>`, `<tbody>`, `<tr>`, `<th>`, and `<td>` elements instead of a CSS grid of paragraphs.
  * Significantly enhanced the CSS for the new `StatsTable`, utilizing `font-variant-numeric: tabular-nums` and column-specific padding/alignment (`padding-inline`, `min-width`) to guarantee perfect alignment of running timers and move counts, regardless of how drastically the translated header text expands.
  * Forced `color-scheme: light` on the language `<select>` dropdown in dark mode to prevent a known rendering bug on certain Linux desktop environments where native UI popups become unreadable.