### PR TITLE
feat: enhance CI workflows with iOS support and improve job naming

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -14,6 +14,7 @@ concurrency:
 
 jobs:
   create-tag:
+    name: Create Tag and Release
     runs-on: ubuntu-latest
     permissions:
       contents: write # Grants the action permission to push tags and create releases
@@ -175,6 +176,7 @@ jobs:
   # Publish targets for a newly created release tag.
   # Add more publish jobs here (for example Docker Hub, ECR, or ACR).
   publish-ghcr:
+    name: Publish Container Image
     needs: create-tag
     if: needs.create-tag.outputs.tag_created == 'true'
     permissions:
@@ -189,6 +191,7 @@ jobs:
   # Deployment targets for a newly created release tag.
   # Add more deploy jobs here (for example Netlify, Cloudflare Pages, or S3/CDN).
   deploy-github-pages:
+    name: Deploy GitHub Pages
     needs: create-tag
     if: needs.create-tag.outputs.tag_created == 'true' && needs.create-tag.outputs.is_prerelease == 'false'
     permissions:
@@ -201,6 +204,7 @@ jobs:
     secrets: inherit
 
   publish-desktop:
+    name: Publish Desktop Artifacts
     needs: create-tag
     if: needs.create-tag.outputs.tag_created == 'true'
     permissions:
@@ -211,11 +215,23 @@ jobs:
     secrets: inherit
 
   publish-android:
+    name: Publish Android Artifacts
     needs: create-tag
     if: needs.create-tag.outputs.tag_created == 'true'
     permissions:
       contents: write
     uses: ./.github/workflows/publish-android.yml
+    with:
+      tag: ${{ needs.create-tag.outputs.current_version }}
+    secrets: inherit
+
+  publish-ios:
+    name: Publish iOS Simulator Artifact
+    needs: create-tag
+    if: needs.create-tag.outputs.tag_created == 'true'
+    permissions:
+      contents: write
+    uses: ./.github/workflows/publish-ios.yml
     with:
       tag: ${{ needs.create-tag.outputs.current_version }}
     secrets: inherit

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,7 +9,7 @@
 # the `language` matrix defined below to confirm you have the correct set of
 # supported CodeQL languages.
 #
-name: "CodeQL"
+name: CodeQL
 
 on:
   push:
@@ -23,7 +23,7 @@ on:
 
 jobs:
   analyze:
-    name: Analyze
+    name: Analyze with CodeQL
     runs-on: ubuntu-latest
     permissions:
       actions: read

--- a/.github/workflows/deploy-github-pages.yml
+++ b/.github/workflows/deploy-github-pages.yml
@@ -24,6 +24,7 @@ concurrency:
 
 jobs:
   deploy:
+    name: Deploy GitHub Pages
     # Skip prerelease tags (for example v1.15.0-rc.1) across all trigger paths.
     if: (inputs.tag == '' && !contains(github.ref_name, '-')) || (inputs.tag != '' && !contains(inputs.tag, '-'))
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-tests.yml
+++ b/.github/workflows/pr-tests.yml
@@ -1,38 +1,38 @@
 name: PR Tests
 
 on:
-    pull_request:
-        types:
-            - opened
-            - reopened
-            - synchronize
-            - ready_for_review
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 concurrency:
-    group: pr-tests-${{ github.event.pull_request.number }}
-    cancel-in-progress: true
+  group: pr-tests-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
-    tests:
-        name: Tests / Vitest
-        if: github.event.pull_request.draft == false
-        runs-on: ubuntu-latest
+  tests:
+    name: Run Vitest Tests
+    if: github.event.pull_request.draft == false
+    runs-on: ubuntu-latest
 
-        steps:
-            - name: Checkout repository
-              uses: actions/checkout@v6
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
 
-            - name: Setup Node.js
-              uses: actions/setup-node@v6
-              with:
-                  node-version: 24
-                  cache: yarn
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+          cache: yarn
 
-            - name: Enable Corepack
-              run: corepack enable
+      - name: Enable Corepack
+        run: corepack enable
 
-            - name: Install dependencies
-              run: yarn install --frozen-lockfile
+      - name: Install dependencies
+        run: yarn install --frozen-lockfile
 
-            - name: Run tests
-              run: yarn test --reporter=verbose
+      - name: Run tests
+        run: yarn test --reporter=verbose

--- a/.github/workflows/publish-android.yml
+++ b/.github/workflows/publish-android.yml
@@ -1,4 +1,4 @@
-name: Build and Publish Android APK
+name: Build and Publish Android Artifacts
 
 on:
   workflow_call:
@@ -29,6 +29,7 @@ on:
 
 jobs:
   build-and-publish:
+    name: Build and Publish Android Artifacts
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/publish-desktop.yml
+++ b/.github/workflows/publish-desktop.yml
@@ -21,6 +21,7 @@ on:
 
 jobs:
   build-and-publish:
+    name: Build and Publish Desktop Artifacts
     runs-on: ${{ matrix.os }}
     permissions:
       contents: write

--- a/.github/workflows/publish-ghcr.yml
+++ b/.github/workflows/publish-ghcr.yml
@@ -1,4 +1,4 @@
-name: Build and Push Docker Image
+name: Build and Publish Docker Image
 
 on:
     workflow_call:
@@ -30,6 +30,7 @@ env:
 
 jobs:
     build-and-push:
+        name: Build and Publish Docker Image
         runs-on: ubuntu-latest
         permissions:
             contents: read

--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -1,0 +1,178 @@
+name: Build and Publish iOS Simulator App
+
+on:
+    workflow_call:
+        inputs:
+            tag:
+                description: "Version without leading v (example: 1.2.3)"
+                required: true
+                type: string
+        secrets:
+            RELEASE_GPG_PRIVATE_KEY:
+                required: true
+            RELEASE_GPG_PASSPHRASE:
+                required: false
+    workflow_dispatch:
+        inputs:
+            tag:
+                description: "Version without leading v (example: 1.2.3)"
+                required: true
+                type: string
+
+jobs:
+    build-and-publish:
+        name: Build and Publish iOS Simulator Artifact
+        runs-on: macos-latest
+        permissions:
+            contents: write
+
+        env:
+            DERIVED_DATA_DIR: ios/App/build/DerivedData
+            SIMULATOR_ZIP_PATH: ios/App/Sokoban-${{ inputs.tag }}-ios-simulator.zip
+
+        steps:
+            - name: Checkout repository at release tag
+              uses: actions/checkout@v6
+              with:
+                  ref: refs/tags/v${{ inputs.tag }}
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v6
+              with:
+                  node-version: 24
+                  cache: yarn
+
+            - name: Enable Corepack
+              run: corepack enable
+
+            - name: Install dependencies
+              run: yarn install --frozen-lockfile
+
+            - name: Build web app
+              run: yarn build
+
+            - name: Ensure iOS platform exists and sync Capacitor
+              run: |
+                  set -euo pipefail
+
+                  if [ ! -d ios/App ]; then
+                    npx cap add ios
+                  fi
+
+                  npx cap sync ios
+
+            - name: Build unsigned iOS app for Simulator
+              run: |
+                  set -euo pipefail
+
+                  xcodebuild \
+                    -workspace ios/App/App.xcworkspace \
+                    -scheme App \
+                    -configuration Debug \
+                    -destination 'generic/platform=iOS Simulator' \
+                    -derivedDataPath "$DERIVED_DATA_DIR" \
+                    CODE_SIGN_IDENTITY="" \
+                    CODE_SIGNING_REQUIRED=NO \
+                    CODE_SIGNING_ALLOWED=NO \
+                    COMPILER_INDEX_STORE_ENABLE=NO \
+                    build
+
+            - name: Package iOS Simulator app bundle
+              run: |
+                  set -euo pipefail
+
+                  app_path="$DERIVED_DATA_DIR/Build/Products/Debug-iphonesimulator/App.app"
+
+                  if [ ! -d "$app_path" ]; then
+                    echo "Expected simulator app was not found at: $app_path"
+                    echo "Available products:"
+                    find "$DERIVED_DATA_DIR/Build/Products" -maxdepth 3 -type d | sort || true
+                    exit 1
+                  fi
+
+                  ditto -c -k --sequesterRsrc --keepParent "$app_path" "$SIMULATOR_ZIP_PATH"
+
+            - name: Import Release GPG Key
+              uses: crazy-max/ghaction-import-gpg@v7
+              with:
+                  gpg_private_key: ${{ secrets.RELEASE_GPG_PRIVATE_KEY }}
+                  passphrase: ${{ secrets.RELEASE_GPG_PASSPHRASE }}
+
+            - name: Generate iOS checksum and signatures
+              run: |
+                  set -euo pipefail
+
+                  release_asset_name="Sokoban-${{ inputs.tag }}-ios-simulator.zip"
+                  temp_dir="$(mktemp -d)"
+                  trap 'rm -rf "$temp_dir"' EXIT
+
+                  cp "$SIMULATOR_ZIP_PATH" "$temp_dir/$release_asset_name"
+
+                  (
+                    cd "$temp_dir"
+                    shasum -a 256 "$release_asset_name" > "$GITHUB_WORKSPACE/${SIMULATOR_ZIP_PATH}.sha256"
+                  )
+
+                  gpg --batch --yes --armor --detach-sign --output "${SIMULATOR_ZIP_PATH}.asc" "$SIMULATOR_ZIP_PATH"
+                  gpg --batch --yes --armor --detach-sign --output "${SIMULATOR_ZIP_PATH}.sha256.asc" "${SIMULATOR_ZIP_PATH}.sha256"
+
+            - name: Upload iOS Simulator app artifact
+              uses: actions/upload-artifact@v7
+              with:
+                  name: ios-build-release-simulator
+                  path: ${{ env.SIMULATOR_ZIP_PATH }}
+                  if-no-files-found: error
+
+            - name: Upload iOS checksum/signature artifacts
+              uses: actions/upload-artifact@v7
+              with:
+                  name: ios-build-release-signatures
+                  path: |
+                      ${{ env.SIMULATOR_ZIP_PATH }}.sha256
+                      ${{ env.SIMULATOR_ZIP_PATH }}.asc
+                      ${{ env.SIMULATOR_ZIP_PATH }}.sha256.asc
+                  if-no-files-found: error
+
+            - name: Upload iOS Simulator app to GitHub Release
+              uses: svenstaro/upload-release-action@v2
+              with:
+                  repo_token: ${{ secrets.GITHUB_TOKEN }}
+                  file: ${{ env.SIMULATOR_ZIP_PATH }}
+                  asset_name: Sokoban-${{ inputs.tag }}-ios-simulator.zip
+                  tag: v${{ inputs.tag }}
+                  overwrite: true
+
+            - name: Upload iOS checksum to GitHub Release
+              uses: svenstaro/upload-release-action@v2
+              with:
+                  repo_token: ${{ secrets.GITHUB_TOKEN }}
+                  file: ${{ env.SIMULATOR_ZIP_PATH }}.sha256
+                  asset_name: Sokoban-${{ inputs.tag }}-ios-simulator.zip.sha256
+                  tag: v${{ inputs.tag }}
+                  overwrite: true
+
+            - name: Upload iOS signature to GitHub Release
+              uses: svenstaro/upload-release-action@v2
+              with:
+                  repo_token: ${{ secrets.GITHUB_TOKEN }}
+                  file: ${{ env.SIMULATOR_ZIP_PATH }}.asc
+                  asset_name: Sokoban-${{ inputs.tag }}-ios-simulator.zip.asc
+                  tag: v${{ inputs.tag }}
+                  overwrite: true
+
+            - name: Upload iOS checksum signature to GitHub Release
+              uses: svenstaro/upload-release-action@v2
+              with:
+                  repo_token: ${{ secrets.GITHUB_TOKEN }}
+                  file: ${{ env.SIMULATOR_ZIP_PATH }}.sha256.asc
+                  asset_name: Sokoban-${{ inputs.tag }}-ios-simulator.zip.sha256.asc
+                  tag: v${{ inputs.tag }}
+                  overwrite: true
+
+            - name: Upload Xcode logs on failure
+              if: failure()
+              uses: actions/upload-artifact@v7
+              with:
+                  name: ios-xcode-logs
+                  path: ios/App/build/DerivedData/Logs
+                  if-no-files-found: ignore

--- a/README.md
+++ b/README.md
@@ -19,8 +19,9 @@ Click the [**Latest Release**](https://github.com/hubertbanas/sokoban/releases/l
 | **Mac (Apple Silicon)** | `Sokoban-<version>-arm64.dmg` |
 | **Mac (Intel)** | `Sokoban-<version>-x64.dmg` |
 | **Android** | `Sokoban-<version>.apk` |
+| **iOS Simulator (macOS)** | `Sokoban-<version>-ios-simulator.zip` |
 
-*(Note: Power users can find portable `.exe` files and native Linux packages like `.deb`, `.rpm`, and `.flatpak` in the full assets list).*
+*(Note: The iOS Simulator asset works only in Xcode Simulator on macOS and cannot be installed on a physical iPhone. Power users can find portable `.exe` files and native Linux packages like `.deb`, `.rpm`, and `.flatpak` in the full assets list).*
 
 ## Quick Controls
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -201,6 +201,7 @@ All builds are containerized for reproducibility. Use `--help` for advanced opti
 - `publish-ghcr.yml`: Reusable GHCR publishing workflow (`workflow_call`) invoked by `auto-tag.yml`; also supports manual dispatch.
 - `publish-desktop.yml`: Reusable desktop packaging workflow (`workflow_call`) invoked by `auto-tag.yml`; builds and publishes desktop release assets with `.sha256` checksums and `.asc` detached signatures.
 - `publish-android.yml`: Reusable Android publish workflow (`workflow_call`) invoked by `auto-tag.yml`; builds signed Android release artifacts (`.apk` and `.aab`) and publishes them with `.sha256` checksums and `.asc` detached signatures.
+- `publish-ios.yml`: Reusable iOS publishing workflow (`workflow_call`) invoked by `auto-tag.yml`; builds an unsigned iOS Simulator `.app` bundle, packages it as a `.zip`, and publishes it with `.sha256` checksums and `.asc` detached signatures.
 - `codeql-analysis.yml`: Static security analysis.
 
 Docs-only changes (for example README edits) do not create release tags, so they do not trigger Docker publish or Pages deployment.
@@ -216,6 +217,11 @@ Docs-only changes (for example README edits) do not create release tags, so they
 - `ANDROID_KEY_ALIAS`: Keystore key alias.
 - `ANDROID_KEYSTORE_PASSWORD`: Keystore password.
 - `ANDROID_KEY_PASSWORD`: Key password.
+
+### CI Secrets (iOS Simulator Publish)
+
+- No Apple certificates or provisioning-profile secrets are required because the iOS artifact is a Simulator build.
+- The workflow reuses release-signing secrets (`RELEASE_GPG_PRIVATE_KEY`, optional `RELEASE_GPG_PASSPHRASE`) for `.zip` and checksum signatures.
 
 Release note extraction expects changelog headings in this format:
 
@@ -284,6 +290,15 @@ gpg --verify "$APK.asc" "$APK"
 sha256sum -c "$AAB.sha256"
 gpg --verify "$AAB.sha256.asc" "$AAB.sha256"
 gpg --verify "$AAB.asc" "$AAB"
+```
+
+iOS Simulator (unsigned bundle):
+
+```bash
+ASSET="Sokoban-<version>-ios-simulator.zip"
+shasum -a 256 -c "$ASSET.sha256"
+gpg --verify "$ASSET.sha256.asc" "$ASSET.sha256"
+gpg --verify "$ASSET.asc" "$ASSET"
 ```
 
 Signed source archive:

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
   "devDependencies": {
     "@capacitor/android": "^8.2.0",
     "@capacitor/cli": "^8.2.0",
+    "@capacitor/ios": "^8.2.0",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/jest-dom": "6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -110,6 +110,11 @@
   dependencies:
     tslib "^2.1.0"
 
+"@capacitor/ios@^8.2.0":
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/@capacitor/ios/-/ios-8.3.4.tgz#467f75e00c14923c0d73adb698d02b3d9f996b34"
+  integrity sha512-XvvnPFWWP/gwwO811ue7nEBKSZqDCIB8hxGgWV6iXA7DSVLqMOEmQdfHj94kkVxof2wL9XWHypu3ayDULo7U5w==
+
 "@csstools/color-helpers@^6.0.2":
   version "6.0.2"
   resolved "https://registry.yarnpkg.com/@csstools/color-helpers/-/color-helpers-6.0.2.tgz#82c59fd30649cf0b4d3c82160489748666e6550b"


### PR DESCRIPTION
### Description
This Pull Request introduces a dedicated continuous integration pipeline for Apple environments by automatically building and releasing unsigned iOS Simulator artifacts. Additionally, it standardizes and clarifies job naming conventions across all existing GitHub Actions workflows to improve observability within the CI/CD dashboard.

### Key Changes
* **iOS Build Pipeline:**
  * Added `@capacitor/ios` to the project dependencies.
  * Created `publish-ios.yml` to automatically compile an unsigned iOS app using `xcodebuild`, package it using `ditto`, generate cryptographic checksums and GPG signatures, and attach the resulting `.zip` to GitHub Releases.
  * Integrated the iOS publish step into the primary `auto-tag.yml` release orchestrator.
* **CI/CD Readability:**
  * Standardized `name` properties across all GitHub Actions files (`pr-tests.yml`, `codeql-analysis.yml`, `publish-desktop.yml`, `publish-android.yml`, `publish-ghcr.yml`, and `deploy-github-pages.yml`) so that workflow steps display clearly in the GitHub Actions UI.
* **Documentation Updates:**
  * Updated `README.md` to list the new iOS Simulator artifact in the downloads table, noting its restriction to the macOS Xcode Simulator.
  * Updated `docs/development.md` to detail the new iOS publishing workflow, the absence of Apple Developer secret requirements, and the commands needed to verify the artifact's `.asc` signatures.