### PR TITLE
feat: enhance iOS build process with project detection and error hand…

### DIFF
--- a/.github/workflows/publish-ios.yml
+++ b/.github/workflows/publish-ios.yml
@@ -61,21 +61,50 @@ jobs:
 
                   npx cap sync ios
 
+                  if [ ! -d ios/App/App.xcodeproj ]; then
+                    echo "Expected Xcode project not found at ios/App/App.xcodeproj"
+                    echo "Available iOS files:"
+                    find ios/App -maxdepth 2 -type d | sort || true
+                    exit 1
+                  fi
+
             - name: Build unsigned iOS app for Simulator
               run: |
+
                   set -euo pipefail
 
-                  xcodebuild \
-                    -workspace ios/App/App.xcworkspace \
-                    -scheme App \
-                    -configuration Debug \
-                    -destination 'generic/platform=iOS Simulator' \
-                    -derivedDataPath "$DERIVED_DATA_DIR" \
-                    CODE_SIGN_IDENTITY="" \
-                    CODE_SIGNING_REQUIRED=NO \
-                    CODE_SIGNING_ALLOWED=NO \
-                    COMPILER_INDEX_STORE_ENABLE=NO \
-                    build
+                  if [ -d ios/App/App.xcworkspace ]; then
+                    echo "Using Xcode workspace"
+                    xcodebuild \
+                      -workspace ios/App/App.xcworkspace \
+                      -scheme App \
+                      -configuration Debug \
+                      -destination 'generic/platform=iOS Simulator' \
+                      -derivedDataPath "$DERIVED_DATA_DIR" \
+                      CODE_SIGN_IDENTITY="" \
+                      CODE_SIGNING_REQUIRED=NO \
+                      CODE_SIGNING_ALLOWED=NO \
+                      COMPILER_INDEX_STORE_ENABLE=NO \
+                      build
+                  elif [ -d ios/App/App.xcodeproj ]; then
+                    echo "Using Xcode project"
+                    xcodebuild \
+                      -project ios/App/App.xcodeproj \
+                      -scheme App \
+                      -configuration Debug \
+                      -destination 'generic/platform=iOS Simulator' \
+                      -derivedDataPath "$DERIVED_DATA_DIR" \
+                      CODE_SIGN_IDENTITY="" \
+                      CODE_SIGNING_REQUIRED=NO \
+                      CODE_SIGNING_ALLOWED=NO \
+                      COMPILER_INDEX_STORE_ENABLE=NO \
+                      build
+                  else
+                    echo "Neither ios/App/App.xcworkspace nor ios/App/App.xcodeproj exists"
+                    echo "Available iOS files:"
+                    find ios/App -maxdepth 2 -type d | sort || true
+                    exit 1
+                  fi
 
             - name: Package iOS Simulator app bundle
               run: |


### PR DESCRIPTION
### Description
This PR enhances the iOS Simulator build pipeline to dynamically detect the Xcode project structure, resolving build failures caused by missing workspace files.

### Motivation
Newer versions of Capacitor default to using Swift Package Manager (SPM), which generates an `.xcodeproj` file but does not generate an `.xcworkspace` file. This update ensures the continuous integration pipeline gracefully handles both modern SPM project structures and legacy CocoaPods workspace structures. 

### Changes Included
* Added conditional logic to `publish-ios.yml` to execute `xcodebuild` with the `-workspace` flag if a workspace exists, or the `-project` flag if only a project exists.
* Added a pre-build validation check to verify the existence of `ios/App/App.xcodeproj` immediately after the Capacitor sync step.
* Added detailed error logging to output the directory tree if the expected Xcode project files are not found, improving pipeline debugging.